### PR TITLE
Add LicenseManager for user access control

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -60,6 +60,10 @@ namespace VisualHFT
 
         private async Task LoadPlugins()
         {
+            //Load the license manager and check if the user has access to the plugin
+            LicenseManager.Instance.LoadFromKeygen();
+
+
             PluginManager.PluginManager.AllPluginsReloaded = false;
             await PluginManager.PluginManager.LoadPlugins();
             await PluginManager.PluginManager.StartPlugins();

--- a/PluginManager/PluginManager.cs
+++ b/PluginManager/PluginManager.cs
@@ -1,11 +1,9 @@
-﻿using log4net.Plugin;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
 using VisualHFT.Commons.Helpers;
 using VisualHFT.Commons.Studies;
@@ -169,7 +167,11 @@ namespace VisualHFT.PluginManager
                             var plugin = Activator.CreateInstance(type) as IPlugin;
                             if (string.IsNullOrEmpty(plugin.Name))
                                 continue;
+                            if (!LicenseManager.Instance.HasAccess(plugin.RequiredLicenseLevel))
+                                continue;
+
                             plugin.Status = ePluginStatus.LOADING;
+                            
                             ALL_PLUGINS.Add(plugin);
                             log.Info("Plugin assemblies for: " + plugin.Name + " have loaded OK.");
                         }

--- a/VisualHFT.Commons/Helpers/LicenseManager.cs
+++ b/VisualHFT.Commons/Helpers/LicenseManager.cs
@@ -1,0 +1,21 @@
+﻿using VisualHFT.Enums;
+
+public class LicenseManager
+{
+    private static LicenseManager _instance = new LicenseManager();
+    public static LicenseManager Instance => _instance;
+
+    public eLicenseLevel CurrentLicenseLevel { get; private set; } = eLicenseLevel.COMMUNITY;
+
+    public bool HasAccess(eLicenseLevel required)
+    {
+        return CurrentLicenseLevel >= required;
+    }
+
+    // Later: this will be populated via API
+    public void LoadFromKeygen()
+    {
+        CurrentLicenseLevel = eLicenseLevel.COMMUNITY;
+    }
+}
+

--- a/VisualHFT.Commons/Model/enums.cs
+++ b/VisualHFT.Commons/Model/enums.cs
@@ -129,7 +129,14 @@ namespace VisualHFT.Enums
         MARKET_CONNECTOR,
     }
 
-
+    public enum eLicenseLevel
+    {
+        COMMUNITY,
+        AMATEUR,
+        CORE,
+        PRO,
+        ENTERPRISE
+    }
 
     public enum eTestingPrivateMessageScenario
     {

--- a/VisualHFT.Commons/PluginManager/BasePluginDataRetriever.cs
+++ b/VisualHFT.Commons/PluginManager/BasePluginDataRetriever.cs
@@ -1,11 +1,8 @@
-﻿using log4net.Plugin;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using VisualHFT.Commons.Helpers;
-using VisualHFT.Commons.Studies;
 using VisualHFT.DataRetriever;
-using VisualHFT.DataTradeRetriever;
 using VisualHFT.Enums;
 using VisualHFT.Helpers;
 using VisualHFT.Model;
@@ -42,6 +39,8 @@ namespace VisualHFT.Commons.PluginManager
         {
             get { return ePluginType.MARKET_CONNECTOR; }
         }
+        public virtual eLicenseLevel RequiredLicenseLevel => eLicenseLevel.COMMUNITY; // Default to Community, override in derived classes if needed
+
         protected abstract void LoadSettings();
         protected abstract void SaveSettings();
         protected abstract void InitializeDefaultSettings();

--- a/VisualHFT.Commons/PluginManager/BasePluginMultiStudy.cs
+++ b/VisualHFT.Commons/PluginManager/BasePluginMultiStudy.cs
@@ -30,6 +30,7 @@ namespace VisualHFT.Commons.PluginManager
         protected abstract void LoadSettings();
         protected abstract void SaveSettings();
         protected abstract void InitializeDefaultSettings();
+        public virtual eLicenseLevel RequiredLicenseLevel => eLicenseLevel.COMMUNITY; // Default to Community, override in derived classes if needed
 
 
         public BasePluginMultiStudy()

--- a/VisualHFT.Commons/PluginManager/BasePluginStudy.cs
+++ b/VisualHFT.Commons/PluginManager/BasePluginStudy.cs
@@ -41,6 +41,8 @@ namespace VisualHFT.Commons.PluginManager
         {
             get { return ePluginType.STUDY; }
         }
+        public virtual eLicenseLevel RequiredLicenseLevel => eLicenseLevel.COMMUNITY; // Default to Community, override in derived classes if needed
+
         protected abstract void LoadSettings();
         protected abstract void SaveSettings();
         protected abstract void InitializeDefaultSettings();

--- a/VisualHFT.Commons/PluginManager/IPlugin.cs
+++ b/VisualHFT.Commons/PluginManager/IPlugin.cs
@@ -13,7 +13,7 @@ namespace VisualHFT.PluginManager
         ISetting Settings { get; set; }
         ePluginStatus Status { get; set; }
         Action CloseSettingWindow { get; set; }
-
+        eLicenseLevel RequiredLicenseLevel { get; }
         string GetPluginUniqueID();
         object GetUISettings(); //using object type because this csproj doesn't support UI
         object GetCustomUI();   //Allow to setup own UI for the plugin

--- a/VisualHFT.csproj
+++ b/VisualHFT.csproj
@@ -19,6 +19,7 @@
     <Compile Remove="VisualHFT.DataRetriever.TestingFramework\**" />
     <Compile Remove="VisualHFT.MarketConnectors.Test\**" />
     <Compile Remove="VisualHFT.Plugins\**" />
+    <Compile Remove="VisualHFT.TriggerService.TestingFramework\**" />
     <EmbeddedResource Remove="demoTradingCore\**" />
     <EmbeddedResource Remove="packages\**" />
     <EmbeddedResource Remove="VisualHFT.Commons.WPF\**" />
@@ -26,6 +27,7 @@
     <EmbeddedResource Remove="VisualHFT.DataRetriever.TestingFramework\**" />
     <EmbeddedResource Remove="VisualHFT.MarketConnectors.Test\**" />
     <EmbeddedResource Remove="VisualHFT.Plugins\**" />
+    <EmbeddedResource Remove="VisualHFT.TriggerService.TestingFramework\**" />
     <None Remove="demoTradingCore\**" />
     <None Remove="packages\**" />
     <None Remove="VisualHFT.Commons.WPF\**" />
@@ -33,6 +35,7 @@
     <None Remove="VisualHFT.DataRetriever.TestingFramework\**" />
     <None Remove="VisualHFT.MarketConnectors.Test\**" />
     <None Remove="VisualHFT.Plugins\**" />
+    <None Remove="VisualHFT.TriggerService.TestingFramework\**" />
     <Page Remove="demoTradingCore\**" />
     <Page Remove="packages\**" />
     <Page Remove="VisualHFT.Commons.WPF\**" />
@@ -40,6 +43,7 @@
     <Page Remove="VisualHFT.DataRetriever.TestingFramework\**" />
     <Page Remove="VisualHFT.MarketConnectors.Test\**" />
     <Page Remove="VisualHFT.Plugins\**" />
+    <Page Remove="VisualHFT.TriggerService.TestingFramework\**" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduced a new `LicenseManager` class to manage user license levels and access to features. Updated `LoadPlugins` in `App.xaml.cs` to load user profile information. Added license level checks in `PluginManager.cs` to restrict plugin loading based on user access rights. Defined a new `eLicenseLevel` enum in `enums.cs` with various license tiers. Updated several classes in the `VisualHFT.Commons.PluginManager` namespace to include a `RequiredLicenseLevel` property. Modified the `IPlugin` interface to enforce licensing requirements for plugins. Cleaned up the project file by removing references to `VisualHFT.TriggerService.TestingFramework`.