### PR TITLE
Preserve FIFO order when pausing HelperCustomQueue

### DIFF
--- a/VisualHFT.Commons/Helpers/HelperCustomQueue.cs
+++ b/VisualHFT.Commons/Helpers/HelperCustomQueue.cs
@@ -270,70 +270,14 @@ public class HelperCustomQueue<T> : IDisposable
 
                 // Process all available items in batch
                 int processedCount = 0;
-                while (_reader.TryRead(out var item))
+                while (!Volatile.Read(ref _isPaused) &&
+                       _reader.TryRead(out var item))
                 {
                     if (_monitorHealth)
                         Interlocked.Decrement(ref _currentDepth); // Track depth
 
-                    // ✅ FIX: Check pause BEFORE processing, but item is already taken
-                    // If paused mid-batch, we need to process this item then stop
                     if (Volatile.Read(ref _disposed))
                         break;
-
-                    // ✅ FIX: If paused, put item back or process it - choosing to process
-                    // since we already took it (alternative: use Peek if available)
-                    if (Volatile.Read(ref _isPaused))
-                    {
-                        // ✅ FIX: Only re-add if channel is still accepting writes
-                        if (!_reader.Completion.IsCompleted)
-                        {
-                            try
-                            {
-                                if (!_writer.TryWrite(item))
-                                {
-                                    // TryWrite failed - process item to prevent loss
-                                    try
-                                    {
-                                        _actionOnRead(item);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        _onError?.Invoke(ex);
-                                    }
-                                }
-                                else
-                                {
-                                    if (_monitorHealth)
-                                        Interlocked.Increment(ref _currentDepth); // Track depth
-                                }
-                            }
-                            catch (ChannelClosedException)
-                            {
-                                // Channel was closed between check and write - process item instead
-                                try
-                                {
-                                    _actionOnRead(item);
-                                }
-                                catch (Exception ex)
-                                {
-                                    _onError?.Invoke(ex);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // Channel is complete, process the item we already took
-                            try
-                            {
-                                _actionOnRead(item);
-                            }
-                            catch (Exception ex)
-                            {
-                                _onError?.Invoke(ex);
-                            }
-                        }
-                        break;
-                    }
 
                     try
                     {

--- a/VisualHFT.sln
+++ b/VisualHFT.sln
@@ -71,6 +71,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualHFT.Tests.Infrastruct
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualHFT.TriggerService.Tests", "tests\Integration\VisualHFT.TriggerService.Tests\VisualHFT.TriggerService.Tests.csproj", "{38877CF7-B1C9-4446-815F-B624A651AD1A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualHFT.Commons.Tests", "tests\Unit\VisualHFT.Commons.Tests\VisualHFT.Commons.Tests.csproj", "{B2430246-9215-40B0-B7FB-8884900C7C46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -393,6 +395,18 @@ Global
 		{38877CF7-B1C9-4446-815F-B624A651AD1A}.Release|x64.Build.0 = Release|Any CPU
 		{38877CF7-B1C9-4446-815F-B624A651AD1A}.Release|x86.ActiveCfg = Release|Any CPU
 		{38877CF7-B1C9-4446-815F-B624A651AD1A}.Release|x86.Build.0 = Release|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Debug|x86.Build.0 = Debug|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Release|x64.Build.0 = Release|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2430246-9215-40B0-B7FB-8884900C7C46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -422,6 +436,7 @@ Global
 		{CC112233-4455-6677-8899-AABBCCDDEEFF} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{A8486075-32D7-417B-89C5-C23DB845E9EE} = {CC112233-4455-6677-8899-AABBCCDDEEFF}
 		{38877CF7-B1C9-4446-815F-B624A651AD1A} = {28A6993C-471E-82FE-7D9E-AD3B1EC22BD9}
+		{B2430246-9215-40B0-B7FB-8884900C7C46} = {9D556B49-86D1-93A7-9596-FFAAB74EC556}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9EDE643D-268A-4BB9-85A6-F32F11E40516}

--- a/tests/Unit/VisualHFT.Commons.Tests/HelperCustomQueueTests.cs
+++ b/tests/Unit/VisualHFT.Commons.Tests/HelperCustomQueueTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+
+namespace VisualHFT.Commons.Tests;
+
+public class HelperCustomQueueTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan PauseObservationTimeout = TimeSpan.FromMilliseconds(250);
+
+    [Fact]
+    public void PauseDuringBatch_PreservesFifoOrder()
+    {
+        var processed = new ConcurrentQueue<string>();
+        var errors = new ConcurrentQueue<Exception>();
+        using var processingFirstItem = new ManualResetEventSlim();
+        using var releaseFirstItem = new ManualResetEventSlim();
+        using var firstItemProcessed = new ManualResetEventSlim();
+        using var allItemsProcessed = new CountdownEvent(3);
+
+        using var queue = new HelperCustomQueue<string>(
+            "fifo-pause-test",
+            item =>
+            {
+                if (item == "A")
+                {
+                    processingFirstItem.Set();
+                    if (!releaseFirstItem.Wait(TestTimeout, TestContext.Current.CancellationToken))
+                        throw new TimeoutException("Timed out waiting to release the first item.");
+                }
+
+                processed.Enqueue(item);
+                allItemsProcessed.Signal();
+
+                if (item == "A")
+                    firstItemProcessed.Set();
+            },
+            errors.Enqueue);
+
+        queue.Add("A");
+        Assert.True(processingFirstItem.Wait(TestTimeout, TestContext.Current.CancellationToken));
+
+        queue.Add("B");
+        queue.Add("C");
+        queue.PauseConsumer();
+        releaseFirstItem.Set();
+
+        Assert.True(firstItemProcessed.Wait(TestTimeout, TestContext.Current.CancellationToken));
+        Assert.False(allItemsProcessed.Wait(PauseObservationTimeout, TestContext.Current.CancellationToken));
+
+        queue.ResumeConsumer();
+
+        Assert.True(allItemsProcessed.Wait(TestTimeout, TestContext.Current.CancellationToken));
+        Assert.Equal(new[] { "A", "B", "C" }, processed.ToArray());
+        Assert.Equal(3, processed.Distinct().Count());
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void PauseBeforeEnqueue_DoesNotProcessUntilResume()
+    {
+        var processed = new ConcurrentQueue<int>();
+        var errors = new ConcurrentQueue<Exception>();
+        using var consumerStarted = new ManualResetEventSlim();
+        using var anyItemProcessed = new ManualResetEventSlim();
+        using var allItemsProcessed = new CountdownEvent(3);
+
+        using var queue = new HelperCustomQueue<int>(
+            "pause-before-enqueue-test",
+            item =>
+            {
+                if (item == 0)
+                {
+                    consumerStarted.Set();
+                    return;
+                }
+
+                processed.Enqueue(item);
+                anyItemProcessed.Set();
+                allItemsProcessed.Signal();
+            },
+            errors.Enqueue);
+
+        queue.Add(0);
+        Assert.True(consumerStarted.Wait(TestTimeout, TestContext.Current.CancellationToken));
+
+        queue.PauseConsumer();
+        queue.Add(1);
+        queue.Add(2);
+        queue.Add(3);
+
+        Assert.False(anyItemProcessed.Wait(PauseObservationTimeout, TestContext.Current.CancellationToken));
+
+        queue.ResumeConsumer();
+
+        Assert.True(allItemsProcessed.Wait(TestTimeout, TestContext.Current.CancellationToken));
+        Assert.Equal(new[] { 1, 2, 3 }, processed.ToArray());
+        Assert.Equal(3, processed.Distinct().Count());
+        Assert.Empty(errors);
+    }
+}

--- a/tests/Unit/VisualHFT.Commons.Tests/VisualHFT.Commons.Tests.csproj
+++ b/tests/Unit/VisualHFT.Commons.Tests/VisualHFT.Commons.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\VisualHFT.Commons\VisualHFT.Commons.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Check the pause state before reading the next item from `HelperCustomQueue<T>`.
- Remove the mid-batch path that re-enqueued an already-dequeued item.
- Add focused regression tests for pausing during a batch and before enqueueing.

## Root cause

The consumer previously dequeued an item before checking whether a pause had been requested. When paused, it wrote that item back to the same channel.

Re-enqueueing moved the item behind entries already in the channel, so an ordered sequence such as `A, B, C` could be processed as `A, C, B`.

This is particularly problematic for ordered market-data streams and exchange sequence handling.

## Behavior

The consumer now checks the pause state before claiming the next item. An item already claimed because of a concurrent pause is processed once, and the following loop iteration observes the pause.

No shutdown, disposal, public API, monitoring, or connector behavior is changed.

## Tests

- `PauseDuringBatch_PreservesFifoOrder`
- `PauseBeforeEnqueue_DoesNotProcessUntilResume`

Validation completed:

- Commons tests: 2 passed
- MarketResilience tests: 53 passed
- MarketData connector tests: 18 passed
- `VisualHFT.Commons` build: passed
