### PR TITLE
Clarify README documentation links and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 <p align="center">
   <a href="https://visualhft.com">Website</a> ·
-  <a href="docs/README.md">Documentation</a> ·
+  <a href="https://visualhft.com/docs">Documentation</a> ·
+  <a href="docs/README.md">OSS doc sources</a> ·
   <a href="https://visualhft.com/discord">Discord</a> ·
   <a href="https://github.com/visualHFT/VisualHFT/discussions">Discussions</a>
 </p>
@@ -57,7 +58,7 @@ git clone https://github.com/visualHFT/VisualHFT.git
 
 Open `VisualHFT/VisualHFT.sln` in Visual Studio and build the solution. Set `VisualHFT` as the startup project and press <kbd>F5</kbd>. The Dashboard opens first. Select an available provider and a normalised symbol such as `BTC/USD` in the order-book panel.
 
-Need help with setup? See [Troubleshooting](docs/troubleshooting.md) or ask in [Discord](https://visualhft.com/discord).
+Need help with setup? Use the public [VisualHFT documentation](https://visualhft.com/docs), see the repository [troubleshooting source](docs/troubleshooting.md), or ask in [Discord](https://visualhft.com/discord).
 
 ## Included in this repository
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,10 @@
 # VisualHFT documentation
 
-Use this guide to install VisualHFT, understand its public architecture, and build extensions.
+The branded public documentation experience is available at [visualhft.com/docs](https://visualhft.com/docs).
+
+The Markdown files in this directory remain the canonical editable sources for open-source build, architecture, extension, and troubleshooting guidance. The website projects an explicit allowlist from a pinned repository commit and links every projected page back here. Update the source in this repository; do not maintain a second copy in the website.
+
+Use these source guides to install VisualHFT, understand its public architecture, and build extensions:
 
 - [Getting started](getting-started.md)
 - [Architecture](architecture.md)


### PR DESCRIPTION
- Main "Documentation" link now points to the public website
- Added "OSS doc sources" link to Markdown files in repo
- Setup help directs users to public docs, troubleshooting, or Discord
- Explained that website is built from repo Markdown, which is canonical
- Instructed contributors to update only repo Markdown files
- Clarified documentation guide links