### PR TITLE
fix(connectors): reconnection engine reads the start outcome; Coinbase, Bitfinex and Kraken reconnect cleanly

### DIFF
--- a/SDK-MarketConnectorTemplate/TemplateExchangePlugin.cs
+++ b/SDK-MarketConnectorTemplate/TemplateExchangePlugin.cs
@@ -49,8 +49,9 @@ namespace MarketConnector.Template
 
         public TemplateExchangePlugin()
         {
-            // Wire automatic reconnection. The base class invokes
-            // InternalStartAsync() whenever HandleConnectionLost() fires.
+            // Register the internal start with the base class. On each reconnection attempt the
+            // engine calls StartAsync(), which awaits InternalStartAsync() itself; the engine does
+            // not invoke the registered action separately.
             SetReconnectionAction(InternalStartAsync);
             log.Info($"{Name} has been loaded.");
         }

--- a/VisualHFT.Commons/Model/OrderBook.cs
+++ b/VisualHFT.Commons/Model/OrderBook.cs
@@ -322,6 +322,10 @@ namespace VisualHFT.Model
             bool ret = true;
             using (_data.EnterWriteLock())
             {
+                // See Clear(): the in-lock null re-check is the guard. Reports failure rather than
+                // success, because nothing was loaded.
+                if (_data.Asks == null || _data.Bids == null)
+                    return false;
                 _data.Clear();
 
                 if (bids != null)
@@ -467,6 +471,9 @@ namespace VisualHFT.Model
         {
             using (_data.EnterWriteLock())
             {
+                // See Clear(): the in-lock null re-check is the guard.
+                if (_data.Asks == null || _data.Bids == null)
+                    return;
                 // Clear existing data and return items to shared pool to avoid allocation
                 _data.Clear();
 
@@ -629,8 +636,19 @@ namespace VisualHFT.Model
 
         public void Clear()
         {
+            // Disposed -> no-op: a reconnect can dispose the book while a frame is in flight (socket thread
+            // or queue consumer); dropping it keeps that transient benign, like the snapshot getters.
+            if (Volatile.Read(ref _disposed))
+                return;
             using (_data.EnterWriteLock())
             {
+                // OrderBook.Dispose publishes its own _disposed BEFORE _data.Dispose() nulls the side
+                // lists under this same write lock (OrderBookData.Dispose sets its own flag only AFTER
+                // nulling them), so a flag read taken before the lock is only an optimization: a caller
+                // that passed it can still arrive here after the lists are gone. The in-lock re-check is
+                // the guard (the DeleteLevel/CalculateMetrics precedent).
+                if (_data.Asks == null || _data.Bids == null)
+                    return;
                 InternalClear();
                 _data.Clear();
             }
@@ -640,6 +658,9 @@ namespace VisualHFT.Model
         {
             using (_data.EnterWriteLock())
             {
+                // See Clear(): the in-lock null re-check is the guard.
+                if (_data.Asks == null || _data.Bids == null)
+                    return;
                 InternalClear();
                 _data?.Reset();
             }
@@ -651,6 +672,9 @@ namespace VisualHFT.Model
         }
         public virtual void AddOrUpdateLevel(bool? IsBid, string EntryID, double? Price, double? Size, DateTime LocalTimeStamp, DateTime ServerTimeStamp)
         {
+            // See Clear(): a frame still in flight when a reconnect disposes the book is dropped, not thrown on.
+            if (Volatile.Read(ref _disposed))
+                return;
             if (!IsBid.HasValue)
                 return;
 
@@ -664,6 +688,8 @@ namespace VisualHFT.Model
             using (_data.EnterWriteLock())
             {
                 var _list = (IsBid.HasValue && IsBid.Value ? _data.Bids : _data.Asks);
+                if (_list == null)
+                    return;
                 BookItem? itemFound = null;
                 var targetPrice = Price.Value;  // Cache the value
                 var count = _list.Count();
@@ -707,6 +733,8 @@ namespace VisualHFT.Model
             bool willNewItemFallOut = false;
 
             var list = IsBid.Value ? _data.Bids : _data.Asks;
+            if (list == null)
+                return;
             var listCount = list.Count();
             if (IsBid.Value)
             {
@@ -776,7 +804,11 @@ namespace VisualHFT.Model
             // quantize what we store so internals never carry float dust
             Size = QuantizeToDp(Size.Value, this.SizeDecimalPlaces);
 
-            (IsBid.HasValue && IsBid.Value ? _data.Bids : _data.Asks).Update(x => x.Price == Price,
+            var list = (IsBid.HasValue && IsBid.Value ? _data.Bids : _data.Asks);
+            if (list == null)
+                return;
+
+            list.Update(x => x.Price == Price,
                 existingItem =>
                 {
                     double oldSize = existingItem.Size ?? 0.0;

--- a/VisualHFT.Commons/PluginManager/BasePluginDataRetriever.cs
+++ b/VisualHFT.Commons/PluginManager/BasePluginDataRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using VisualHFT.Commons.Extensions;
 using VisualHFT.Commons.Helpers;
 using VisualHFT.DataRetriever;
 using VisualHFT.Enums;
@@ -203,7 +204,8 @@ namespace VisualHFT.Commons.PluginManager
         private Func<Task> _internalStartAsync;
         /// <summary>
         /// To use the internal and automated reconnection process, we need to define and pass a local method, which have defined all the steps required to do the connection.
-        /// This way, the internal reconnection process, could take this, and perform its execution as required.
+        /// The reconnection engine does NOT invoke this action itself: every connector's StartAsync already
+        /// awaits the same internal start, so invoking it here too ran two full connect bursts per attempt.
         /// </summary>
         /// <param name="internalStartAsync">The internal start async.</param>
         protected void SetReconnectionAction(Func<Task> internalStartAsync)
@@ -300,7 +302,7 @@ namespace VisualHFT.Commons.PluginManager
                                 int backoffDelay = (int)Math.Pow(2, _reconnectionAttempt) * 1000 + jitter.Next(0, 1000);
                                 
                                 log.Info($"{this.Name} Reconnection attempt {_reconnectionAttempt} of {maxReconnectionAttempts} after delay {backoffDelay} ms. Reason: {reason}");
-                                await Task.Delay(backoffDelay);
+                                await ReconnectBackoffDelayAsync(backoffDelay);
 
                                 // Final status check before attempting reconnection
                                 if (!forceStartRegardlessStatus && Status == ePluginStatus.STOPPED_FAILED)
@@ -311,11 +313,6 @@ namespace VisualHFT.Commons.PluginManager
 
                                 // Execute reconnection sequence
                                 await StopAsync();
-                                
-                                if (_internalStartAsync != null)
-                                {
-                                    await _internalStartAsync.Invoke();
-                                }
 
                                 // Preserve reconnection state across StartAsync
                                 var _reconnect = _reconnectionAttempt;
@@ -324,20 +321,71 @@ namespace VisualHFT.Commons.PluginManager
                                 _reconnectionAttempt = _reconnect;
                                 _pendingReconnectionRequests = _pendingRec;
 
-                                // Verify reconnection succeeded
-                                if (!forceStartRegardlessStatus && Status == ePluginStatus.STOPPED_FAILED)
+                                // A connector signals a failed start by calling HandleConnectionLost from its own
+                                // catch block, and inside this loop that call is a no-op (the re-entry guard at the
+                                // top of this method already owns the reconnection flag), so StartAsync returns
+                                // normally either way. The status it leaves behind is the only reliable signal.
+                                // The rail shows the LAST provider status announced, so each exit below announces one --
+                                // a silent give-up would keep Gemini's CONNECTED, raised right before it stamps STOPPED_FAILED.
+                                if (Status == ePluginStatus.STARTED)
                                 {
-                                    log.Debug($"{this.Name} Reconnection completed but Status = STOPPED_FAILED");
+                                    // ✅ SUCCESS: Reset counters and exit loop
+                                    log.Info($"{this.Name} Reconnection successful.");
+                                    RaiseOnDataReceived(GetProviderModel(eSESSIONSTATUS.CONNECTED));
+                                    Status = ePluginStatus.STARTED;
+                                    _pendingReconnectionRequests = 0;
+                                    _reconnectionAttempt = 0;
+                                    break; // Exit retry loop on success
+                                }
+                                else if (Status == ePluginStatus.LOADED)
+                                {
+                                    // The plugin declined to start and stays idle by its own decision (e.g. no configured
+                                    // session): retrying is pointless and stamping STARTED over it would be a lie.
+                                    log.Info($"{this.Name} declined to start (Status = LOADED). Reconnection ends without marking it started.");
+                                    RaiseOnDataReceived(GetProviderModel(Status.ToSessionStatus()));
+                                    _pendingReconnectionRequests = 0;
+                                    _reconnectionAttempt = 0;
                                     break;
                                 }
+                                else if (Status == ePluginStatus.STOPPED_FAILED)
+                                {
+                                    // Deliberately NOT gated on forceStartRegardlessStatus: that flag exists to bypass
+                                    // the ENTRY guard above, so a plugin that had previously failed can be restarted at
+                                    // all. It must not override the verdict THIS attempt just produced -- Binance and
+                                    // Gemini set STOPPED_FAILED on a [CantConnectError] deliberately and without retry.
+                                    // Counters are reset here because this is now also the FORCED exit: the settings
+                                    // dialog reloads through HandleConnectionLost(force: true), and leaving the attempt
+                                    // count standing would make the loop start mid-ladder on the next reload and do
+                                    // nothing at all once it reached the cap. Before, the forced case fell through to
+                                    // the throw and was reset by HandleMaxReconnectionAttempts.
+                                    log.Debug($"{this.Name} Reconnection completed but Status = STOPPED_FAILED");
+                                    RaiseOnDataReceived(GetProviderModel(Status.ToSessionStatus()));
+                                    _pendingReconnectionRequests = 0;
+                                    _reconnectionAttempt = 0;
+                                    break;
+                                }
+                                else if (Status == ePluginStatus.STARTING)
+                                {
+                                    // STARTING is the expected shape of a failed start: base.StartAsync() stamps it
+                                    // before any connector work, and a connector reports failure by handing off to
+                                    // HandleConnectionLost, which is a no-op inside this loop (the re-entry guard at the
+                                    // top already owns the flag). Fail the attempt so the catch below counts it and
+                                    // retries, or gives up at the cap.
+                                    throw new InvalidOperationException($"{this.Name} StartAsync returned with Status = {Status}; the attempt did not reach STARTED.");
+                                }
 
-                                // ✅ SUCCESS: Reset counters and exit loop
-                                log.Info($"{this.Name} Reconnection successful.");
-                                RaiseOnDataReceived(GetProviderModel(eSESSIONSTATUS.CONNECTED));
-                                Status = ePluginStatus.STARTED;
+                                // Anything else is NOT a failed attempt, so it is neither retried nor overwritten.
+                                // STOPPED/STOPPING mean somebody stopped the plugin on purpose while it was starting:
+                                // the provider rail calls the retriever's StopAsync() and force-sets STOPPED on a user
+                                // toggle-off. Retrying that fights the user for ~62s of backoff and ends in
+                                // STOPPED_FAILED, which the entry guard above then refuses to restart. Any other
+                                // status takes this same exit because it is not evidence of a failed start either:
+                                // without that evidence the loop neither retries it nor overwrites what it reports.
+                                log.Info($"{this.Name} Reconnection ended without retry: StartAsync returned with Status = {Status} (not a failed start).");
+                                RaiseOnDataReceived(GetProviderModel(Status.ToSessionStatus()));
                                 _pendingReconnectionRequests = 0;
                                 _reconnectionAttempt = 0;
-                                break; // Exit retry loop on success
+                                break;
                             }
                             catch (Exception ex)
                             {

--- a/VisualHFT.Plugins/MarketConnectors.Bitfinex/BitfinexPlugin.cs
+++ b/VisualHFT.Plugins/MarketConnectors.Bitfinex/BitfinexPlugin.cs
@@ -185,10 +185,10 @@ namespace MarketConnectors.Bitfinex
             // teardown lives here rather than in StopAsync because BOTH stop paths - StopAsync and the
             // reconnect's InternalStartAsync - must tear the subscriptions down on the live OUTGOING
             // client and tolerate a dead one.
-            // Error, not Warn: Telemetry/TelemetryAppender.cs sets Threshold = Level.Error, so a Warn
+            // Error, not Warn: the desktop telemetry appender ships nothing below Error, so a Warn
             // never ships and a fleet-wide teardown failure would be invisible in production telemetry.
-            // Not LogException, which would also raise a user-facing notification for a condition this
-            // connector has already handled.
+            // Not LogException: it also increments OperationalErrorsCount, which the feed-health study
+            // reads as a feed failure, and a tolerated teardown is not one.
             try
             {
                 UnattachEventHandlers(deltaSubscription?.Data);

--- a/VisualHFT.Plugins/MarketConnectors.Bitfinex/BitfinexPlugin.cs
+++ b/VisualHFT.Plugins/MarketConnectors.Bitfinex/BitfinexPlugin.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Bitfinex.Net.Enums;
+using Bitfinex.Net.Interfaces.Clients;
 using VisualHFT.Commons.PluginManager;
 using VisualHFT.UserSettings;
 using VisualHFT.Commons.Pools;
@@ -36,8 +37,8 @@ namespace MarketConnectors.Bitfinex
         private bool isReconnecting = false;
 
         private PlugInSettings _settings;
-        private BitfinexSocketClient _socketClient;
-        private BitfinexRestClient _restClient;
+        private IBitfinexSocketClient _socketClient;
+        private IBitfinexRestClient _restClient;
         private Dictionary<string, VisualHFT.Model.OrderBook> _localOrderBooks = new Dictionary<string, VisualHFT.Model.OrderBook>();
         private Dictionary<string, HelperCustomQueue<Tuple<DateTime?, string, BitfinexOrderBookEntry>>> _eventBuffers = new();
         private Dictionary<string, HelperCustomQueue<Tuple<string, BitfinexTradeSimple>>> _tradesBuffers = new();
@@ -73,20 +74,6 @@ namespace MarketConnectors.Bitfinex
         {
             await base.StartAsync(); // ✅ This sets Status = STARTING
 
-            _socketClient = new BitfinexSocketClient(options =>
-            {
-                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
-                    options.ApiCredentials = new BitfinexCredentials(_settings.ApiKey, _settings.ApiSecret);
-                options.Environment = BitfinexEnvironment.Live;
-            });
-
-            _restClient = new BitfinexRestClient(options =>
-            {
-                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
-                    options.ApiCredentials = new BitfinexCredentials(_settings.ApiKey, _settings.ApiSecret);
-                options.Environment = BitfinexEnvironment.Live;
-            });
-
             // ✅ FIX: Explicitly report STARTING status so transition history captures it
             RaiseOnDataReceived(GetProviderModel(eSESSIONSTATUS.CONNECTING));
 
@@ -104,6 +91,39 @@ namespace MarketConnectors.Bitfinex
             }
         }
         
+        /// <summary>Seam so a test can substitute the venue clients and observe their lifetime.</summary>
+        protected virtual IBitfinexSocketClient CreateSocketClient()
+        {
+            return new BitfinexSocketClient(options =>
+            {
+                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
+                    options.ApiCredentials = new BitfinexCredentials(_settings.ApiKey, _settings.ApiSecret);
+                options.Environment = BitfinexEnvironment.Live;
+            });
+        }
+
+        /// <summary>Seam so a test can substitute the venue clients and observe their lifetime.</summary>
+        protected virtual IBitfinexRestClient CreateRestClient()
+        {
+            return new BitfinexRestClient(options =>
+            {
+                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
+                    options.ApiCredentials = new BitfinexCredentials(_settings.ApiKey, _settings.ApiSecret);
+                options.Environment = BitfinexEnvironment.Live;
+            });
+        }
+
+        internal void ReplaceClients()
+        {
+            // The previous clients are torn down by ClearAsync while still alive, then disposed and replaced here,
+            // under the start/stop lock, so a concurrent start cannot dispose a client another thread is subscribing on.
+            _socketClient?.Dispose();
+            _restClient?.Dispose();
+
+            _socketClient = CreateSocketClient();
+            _restClient = CreateRestClient();
+        }
+
         private async Task InternalStartAsync()
         {
             // ✅ FIX: Add synchronization
@@ -111,6 +131,7 @@ namespace MarketConnectors.Bitfinex
             try
             {
                 await ClearAsync();
+                ReplaceClients();
 
                 // Initialize event buffer for each symbol
                 foreach (var symbol in GetAllNormalizedSymbols())
@@ -146,15 +167,6 @@ namespace MarketConnectors.Bitfinex
                 Status = ePluginStatus.STOPPING;
                 log.Info($"{this.Name} is stopping.");
 
-                // ✅ FIX: Force cancel any pending reconnections by closing subscriptions first
-                UnattachEventHandlers(deltaSubscription?.Data);
-                UnattachEventHandlers(tradesSubscription?.Data);
-                
-                if (deltaSubscription != null && deltaSubscription.Data != null)
-                    await deltaSubscription.Data.CloseAsync();
-                if (tradesSubscription != null && tradesSubscription.Data != null)
-                    await tradesSubscription.Data.CloseAsync();
-
                 await ClearAsync();
                 RaiseOnDataReceived(new List<VisualHFT.Model.OrderBook>());
                 RaiseOnDataReceived(GetProviderModel(eSESSIONSTATUS.DISCONNECTED));
@@ -168,10 +180,34 @@ namespace MarketConnectors.Bitfinex
         }
         public async Task ClearAsync()
         {
-            // ✅ Subscription cleanup is done in StopAsync to prevent reconnection races
-            // Only unsubscribe here if not already done
-            if (_socketClient != null)
-                await _socketClient.UnsubscribeAllAsync();
+            // On the reconnect path the outgoing socket is by definition unhealthy; its teardown failing
+            // must not keep the dead client alive or strand StopAsync at STOPPING. The subscription
+            // teardown lives here rather than in StopAsync because BOTH stop paths - StopAsync and the
+            // reconnect's InternalStartAsync - must tear the subscriptions down on the live OUTGOING
+            // client and tolerate a dead one.
+            // Error, not Warn: Telemetry/TelemetryAppender.cs sets Threshold = Level.Error, so a Warn
+            // never ships and a fleet-wide teardown failure would be invisible in production telemetry.
+            // Not LogException, which would also raise a user-facing notification for a condition this
+            // connector has already handled.
+            try
+            {
+                UnattachEventHandlers(deltaSubscription?.Data);
+                UnattachEventHandlers(tradesSubscription?.Data);
+                if (deltaSubscription != null && deltaSubscription.Data != null)
+                    await deltaSubscription.Data.CloseAsync();
+                if (tradesSubscription != null && tradesSubscription.Data != null)
+                    await tradesSubscription.Data.CloseAsync();
+                if (_socketClient != null)
+                    await _socketClient.UnsubscribeAllAsync();
+            }
+            catch (Exception ex)
+            {
+                log.Error($"{this.Name}: teardown of the outgoing socket failed; continuing with local cleanup.", ex);
+            }
+            // Dropped unconditionally, whether the teardown succeeded or threw: the next stop must not
+            // close a subscription belonging to a client this one has already replaced or disposed.
+            deltaSubscription = null;
+            tradesSubscription = null;
 
             _timerPing?.Stop();
             _timerPing?.Dispose();
@@ -342,56 +378,8 @@ namespace MarketConnectors.Bitfinex
                     symbol,
                     Precision.PrecisionLevel0, Frequency.Realtime,
                     _settings.DepthLevels,
-                    data =>
-                    {
-                        // Buffer the events
-                        if (data.Data != null)
-                        {
-                            try
-                            {
-                                if (data.UpdateType == SocketUpdateType.Snapshot)
-                                {
-                                    UpdateOrderBookSnapshot(data.Data, normalizedSymbol);
-                                }
-                                else
-                                {
-                                    // ✅ FIX: Thread-safe buffer access
-                                    HelperCustomQueue<Tuple<DateTime?, string, BitfinexOrderBookEntry>> buffer;
-                                    lock (_buffersLock)
-                                    {
-                                        if (!_eventBuffers.TryGetValue(normalizedSymbol, out buffer))
-                                            return; // Buffer was cleared during reconnection
-                                    }
-                                    
-                                    // The BOOK stamp is the venue's server timestamp carried on the
-                                    // wrapper (DataTime, null when absent) — never local receive time.
-                                    var exchangeTs = ResolveBookTimestamp(data.DataTime);
-                                    foreach (var item in data.Data)
-                                    {
-                                        buffer.Add(
-                                            new Tuple<DateTime?, string, BitfinexOrderBookEntry>(
-                                                exchangeTs, normalizedSymbol, item));
-                                    }
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                var _error = $"Will reconnect. Unhandled error while receiving delta market data for {normalizedSymbol}.";
-                                LogException(ex, _error);
-                                
-                                // ✅ FIX: Pause queue before reconnecting
-                                lock (_buffersLock)
-                                {
-                                    if (_eventBuffers.TryGetValue(normalizedSymbol, out var buffer))
-                                    {
-                                        buffer?.PauseConsumer();
-                                    }
-                                }
-                                
-                                Task.Run(async () => await HandleConnectionLost(_error, ex));
-                            }
-                        }
-                    }, null, new CancellationToken());
+                    data => OnDeltaReceived(data, normalizedSymbol),
+                    null, new CancellationToken());
                 if (deltaSubscription.Success)
                 {
                     AttachEventHandlers(deltaSubscription.Data);
@@ -400,6 +388,62 @@ namespace MarketConnectors.Bitfinex
                 {
                     var _error = $"Unsuccessful deltas subscription for {normalizedSymbol} error: {deltaSubscription.Error}";
                     throw new Exception(_error);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Level2 delta websocket callback (hot path: one call per venue frame). A snapshot frame
+        /// is applied to the book directly; a delta frame is buffered into the symbol's queue,
+        /// whose consumer applies it off the socket thread.
+        /// </summary>
+        internal void OnDeltaReceived(DataEvent<BitfinexOrderBookEntry[]> data, string normalizedSymbol)
+        {
+            // Buffer the events
+            if (data.Data != null)
+            {
+                try
+                {
+                    if (data.UpdateType == SocketUpdateType.Snapshot)
+                    {
+                        UpdateOrderBookSnapshot(data.Data, normalizedSymbol);
+                    }
+                    else
+                    {
+                        // ✅ FIX: Thread-safe buffer access
+                        HelperCustomQueue<Tuple<DateTime?, string, BitfinexOrderBookEntry>> buffer;
+                        lock (_buffersLock)
+                        {
+                            if (!_eventBuffers.TryGetValue(normalizedSymbol, out buffer))
+                                return; // Buffer was cleared during reconnection
+                        }
+                        
+                        // The BOOK stamp is the venue's server timestamp carried on the
+                        // wrapper (DataTime, null when absent) — never local receive time.
+                        var exchangeTs = ResolveBookTimestamp(data.DataTime);
+                        foreach (var item in data.Data)
+                        {
+                            buffer.Add(
+                                new Tuple<DateTime?, string, BitfinexOrderBookEntry>(
+                                    exchangeTs, normalizedSymbol, item));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    var _error = $"Will reconnect. Unhandled error while receiving delta market data for {normalizedSymbol}.";
+                    LogException(ex, _error);
+                    
+                    // ✅ FIX: Pause queue before reconnecting
+                    lock (_buffersLock)
+                    {
+                        if (_eventBuffers.TryGetValue(normalizedSymbol, out var buffer))
+                        {
+                            buffer?.PauseConsumer();
+                        }
+                    }
+                    
+                    Task.Run(async () => await HandleConnectionLost(_error, ex));
                 }
             }
         }
@@ -642,7 +686,11 @@ namespace MarketConnectors.Bitfinex
         }
         private void UpdateOrderBookSnapshot(IEnumerable<BitfinexOrderBookEntry> data, string symbol)
         {
-            if (!_localOrderBooks.TryGetValue(symbol, out VisualHFT.Model.OrderBook? lob))
+            // Treat a null value like an absent key: InitializeSnapshotsAsync seeds a null placeholder
+            // until the REST snapshot replaces it, and Bitfinex sends a Snapshot right after subscribing.
+            // A frame in that window used to dereference the placeholder (the production NullReferenceException
+            // storm) and request a reconnect that reopened it; the REST snapshot seeds the book, so drop it.
+            if (!_localOrderBooks.TryGetValue(symbol, out VisualHFT.Model.OrderBook? lob) || lob == null)
             {
                 return;
             }
@@ -730,12 +778,23 @@ namespace MarketConnectors.Bitfinex
                 _disposed = true;
                 if (disposing)
                 {
-                    UnattachEventHandlers(deltaSubscription?.Data);
-                    UnattachEventHandlers(tradesSubscription?.Data);
-                    
-                    _socketClient?.UnsubscribeAllAsync();
-                    _socketClient?.Dispose();
-                    _restClient?.Dispose();
+                    // App-exit disposal reaches the same dead subscriptions ClearAsync now tolerates, so
+                    // it needs the same guard: a throw here would skip everything below - the ping timer,
+                    // the start/stop lock, the queues and the order books. Error, not Warn, for the reason
+                    // given in ClearAsync.
+                    try
+                    {
+                        UnattachEventHandlers(deltaSubscription?.Data);
+                        UnattachEventHandlers(tradesSubscription?.Data);
+
+                        _socketClient?.UnsubscribeAllAsync();
+                        _socketClient?.Dispose();
+                        _restClient?.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Error($"{this.Name}: teardown of the outgoing socket failed during dispose; continuing with local cleanup.", ex);
+                    }
                     _timerPing?.Dispose();
                     
                     // ✅ FIX: Dispose semaphore

--- a/VisualHFT.Plugins/MarketConnectors.Bitfinex/MarketConnectors.Bitfinex.csproj
+++ b/VisualHFT.Plugins/MarketConnectors.Bitfinex/MarketConnectors.Bitfinex.csproj
@@ -52,4 +52,8 @@
     <ProjectReference Include="..\..\VisualHFT.Commons\VisualHFT.Commons.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MarketConnectors.Bitfinex.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/VisualHFT.Plugins/MarketConnectors.Coinbase/CoinbasePlugin.cs
+++ b/VisualHFT.Plugins/MarketConnectors.Coinbase/CoinbasePlugin.cs
@@ -212,20 +212,20 @@ namespace MarketConnectors.Coinbase
             // teardown lives here rather than in StopAsync because BOTH stop paths - StopAsync and the
             // reconnect's InternalStartAsync - must tear the subscriptions down on the live OUTGOING
             // client and tolerate a dead one.
-            // Error, not Warn: Telemetry/TelemetryAppender.cs sets Threshold = Level.Error, so a Warn
+            // Error, not Warn: the desktop telemetry appender ships nothing below Error, so a Warn
             // never ships and a fleet-wide teardown failure would be invisible in production telemetry.
-            // Not LogException, which would also raise a user-facing notification for a condition this
-            // connector has already handled.
+            // Not LogException: it also increments OperationalErrorsCount, which the feed-health study
+            // reads as a feed failure, and a tolerated teardown is not one.
             try
             {
                 UnattachEventHandlers(deltaSubscription?.Data);
                 UnattachEventHandlers(tradesSubscription?.Data);
-                if (_socketClient != null)
-                    await _socketClient.UnsubscribeAllAsync();
                 if (deltaSubscription != null && deltaSubscription.Data != null)
                     await deltaSubscription.Data.CloseAsync();
                 if (tradesSubscription != null && tradesSubscription.Data != null)
                     await tradesSubscription.Data.CloseAsync();
+                if (_socketClient != null)
+                    await _socketClient.UnsubscribeAllAsync();
             }
             catch (Exception ex)
             {

--- a/VisualHFT.Plugins/MarketConnectors.Coinbase/CoinbasePlugin.cs
+++ b/VisualHFT.Plugins/MarketConnectors.Coinbase/CoinbasePlugin.cs
@@ -10,6 +10,7 @@ using CryptoExchange.Net.Objects;
 using VisualHFT.Commons.Helpers;
 using VisualHFT.Commons.Pools;
 using Coinbase.Net.Clients;
+using Coinbase.Net.Interfaces.Clients;
 using Coinbase.Net.Objects.Models;
 using Coinbase.Net.Enums;
 using Newtonsoft.Json.Linq;
@@ -28,8 +29,8 @@ namespace MarketConnectors.Coinbase
         private bool isReconnecting = false;
 
         private PlugInSettings _settings;
-        private CoinbaseSocketClient _socketClient;
-        private CoinbaseRestClient _restClient;
+        private ICoinbaseSocketClient _socketClient;
+        private ICoinbaseRestClient _restClient;
 
         // ✅ FIX: Use ConcurrentDictionary for thread safety
         private readonly ConcurrentDictionary<string, VisualHFT.Model.OrderBook> _localOrderBooks =
@@ -86,27 +87,6 @@ namespace MarketConnectors.Coinbase
         {
 
             await base.StartAsync(); //call the base first
-            _socketClient = new CoinbaseSocketClient(options =>
-            {
-                if (!string.IsNullOrEmpty(_settings.ApiKey) && !string.IsNullOrEmpty(_settings.ApiSecret))
-                {
-
-                    options.ApiCredentials = new CoinbaseCredentials(_settings.ApiKey, _settings.ApiSecret);
-                }
-
-                options.Environment = CoinbaseEnvironment.Live;
-            });
-
-
-            _restClient = new CoinbaseRestClient(options =>
-            {
-                if (!string.IsNullOrEmpty(_settings.ApiKey) && !string.IsNullOrEmpty(_settings.ApiSecret))
-                {
-                    options.ApiCredentials = new CoinbaseCredentials(_settings.ApiKey, _settings.ApiSecret);
-                }
-
-                options.Environment = CoinbaseEnvironment.Live;
-            });
 
 
             try
@@ -128,6 +108,46 @@ namespace MarketConnectors.Coinbase
             }
         }
 
+        /// <summary>Seam so a test can substitute the venue clients and observe their lifetime.</summary>
+        protected virtual ICoinbaseSocketClient CreateSocketClient()
+        {
+            return new CoinbaseSocketClient(options =>
+            {
+                if (!string.IsNullOrEmpty(_settings.ApiKey) && !string.IsNullOrEmpty(_settings.ApiSecret))
+                {
+
+                    options.ApiCredentials = new CoinbaseCredentials(_settings.ApiKey, _settings.ApiSecret);
+                }
+
+                options.Environment = CoinbaseEnvironment.Live;
+            });
+        }
+
+        /// <summary>Seam so a test can substitute the venue clients and observe their lifetime.</summary>
+        protected virtual ICoinbaseRestClient CreateRestClient()
+        {
+            return new CoinbaseRestClient(options =>
+            {
+                if (!string.IsNullOrEmpty(_settings.ApiKey) && !string.IsNullOrEmpty(_settings.ApiSecret))
+                {
+                    options.ApiCredentials = new CoinbaseCredentials(_settings.ApiKey, _settings.ApiSecret);
+                }
+
+                options.Environment = CoinbaseEnvironment.Live;
+            });
+        }
+
+        internal void ReplaceClients()
+        {
+            // The previous clients are torn down by ClearAsync while still alive, then disposed and replaced here,
+            // under the start/stop lock, so a concurrent start cannot dispose a client another thread is subscribing on.
+            _socketClient?.Dispose();
+            _restClient?.Dispose();
+
+            _socketClient = CreateSocketClient();
+            _restClient = CreateRestClient();
+        }
+
         private async Task InternalStartAsync()
         {
             // ✅ FIX: Add synchronization
@@ -135,6 +155,7 @@ namespace MarketConnectors.Coinbase
             try
             {
                 await ClearAsync();
+                ReplaceClients();
 
                 foreach (var symbol in GetAllNormalizedSymbols())
                 {
@@ -186,14 +207,34 @@ namespace MarketConnectors.Coinbase
 
         public async Task ClearAsync()
         {
-            UnattachEventHandlers(deltaSubscription?.Data);
-            UnattachEventHandlers(tradesSubscription?.Data);
-            if (_socketClient != null)
-                await _socketClient.UnsubscribeAllAsync();
-            if (deltaSubscription != null && deltaSubscription.Data != null)
-                await deltaSubscription.Data.CloseAsync();
-            if (tradesSubscription != null && tradesSubscription.Data != null)
-                await tradesSubscription.Data.CloseAsync();
+            // On the reconnect path the outgoing socket is by definition unhealthy; its teardown failing
+            // must not keep the dead client alive or strand StopAsync at STOPPING. The subscription
+            // teardown lives here rather than in StopAsync because BOTH stop paths - StopAsync and the
+            // reconnect's InternalStartAsync - must tear the subscriptions down on the live OUTGOING
+            // client and tolerate a dead one.
+            // Error, not Warn: Telemetry/TelemetryAppender.cs sets Threshold = Level.Error, so a Warn
+            // never ships and a fleet-wide teardown failure would be invisible in production telemetry.
+            // Not LogException, which would also raise a user-facing notification for a condition this
+            // connector has already handled.
+            try
+            {
+                UnattachEventHandlers(deltaSubscription?.Data);
+                UnattachEventHandlers(tradesSubscription?.Data);
+                if (_socketClient != null)
+                    await _socketClient.UnsubscribeAllAsync();
+                if (deltaSubscription != null && deltaSubscription.Data != null)
+                    await deltaSubscription.Data.CloseAsync();
+                if (tradesSubscription != null && tradesSubscription.Data != null)
+                    await tradesSubscription.Data.CloseAsync();
+            }
+            catch (Exception ex)
+            {
+                log.Error($"{this.Name}: teardown of the outgoing socket failed; continuing with local cleanup.", ex);
+            }
+            // Dropped unconditionally, whether the teardown succeeded or threw: the next stop must not
+            // close a subscription belonging to a client this one has already replaced or disposed.
+            deltaSubscription = null;
+            tradesSubscription = null;
             _timerPing?.Stop();
             _timerPing?.Dispose();
 
@@ -312,51 +353,8 @@ namespace MarketConnectors.Coinbase
                 log.Info($"{this.Name}: sending WS Delta Subscription {normalizedSymbol} ");
                 deltaSubscription = await _socketClient.AdvancedTradeApi.SubscribeToOrderBookUpdatesAsync(
                     symbol,
-                    data =>
-                    {
-                        // Buffer the events
-                        if (data.Data != null)
-                        {
-                            try
-                            {
-                                if (data.UpdateType == SocketUpdateType.Snapshot)
-                                {
-                                    return; //not valid condition
-                                }
-                                else
-                                {
-                                    if (Math.Abs(DateTime.Now.Subtract(data.ReceiveTime.ToLocalTime()).TotalSeconds) > 1)
-                                    {
-                                        var _msg =
-                                            $"Rates are coming late at {Math.Abs(DateTime.Now.Subtract(data.ReceiveTime.ToLocalTime()).TotalSeconds)} seconds.";
-                                        log.Warn(_msg);
-                                        HelperNotificationManager.Instance.AddNotification(this.Name, _msg,
-                                            HelprNorificationManagerTypes.WARNING,
-                                            HelprNorificationManagerCategories.PLUGINS);
-                                    }
-
-                                    // The BOOK stamp is the venue's own event time (newest entry
-                                    // "event_time", null when absent) — ReceiveTime stays the
-                                    // freshness-warn input only, never the book stamp.
-                                    _eventBuffers[normalizedSymbol].Add(
-                                        new Tuple<DateTime?, string, CoinbaseOrderBookUpdate>(
-                                            ResolveBookTimestamp(data.Data), normalizedSymbol, data.Data));
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                string _normalizedSymbol = "(null)";
-                                if (data != null && data.Data != null)
-                                    _normalizedSymbol = GetNormalizedSymbol(data.Symbol);
-
-
-                                var _error =
-                                    $"Will reconnect. Unhandled error while receiving delta market data for {_normalizedSymbol}.";
-                                LogException(ex, _error);
-                                Task.Run(async () => await HandleConnectionLost(_error, ex));
-                            }
-                        }
-                    }, new CancellationToken());
+                    data => OnDeltaReceived(data, normalizedSymbol),
+                    new CancellationToken());
                 if (deltaSubscription.Success)
                 {
                     AttachEventHandlers(deltaSubscription.Data);
@@ -371,7 +369,65 @@ namespace MarketConnectors.Coinbase
             }
         }
 
-        private async Task InitializeSnapshotsAsync()
+        /// <summary>
+        /// Level2 delta websocket callback (hot path: one call per venue frame). Buffers the frame
+        /// into the symbol's queue; the queue consumer applies it to the book off the socket thread.
+        /// </summary>
+        internal void OnDeltaReceived(DataEvent<CoinbaseOrderBookUpdate> data, string normalizedSymbol)
+        {
+            // Buffer the events
+            if (data.Data != null)
+            {
+                try
+                {
+                    if (data.UpdateType == SocketUpdateType.Snapshot)
+                    {
+                        return; //not valid condition
+                    }
+                    else
+                    {
+                        if (Math.Abs(DateTime.Now.Subtract(data.ReceiveTime.ToLocalTime()).TotalSeconds) > 1)
+                        {
+                            var _msg =
+                                $"Rates are coming late at {Math.Abs(DateTime.Now.Subtract(data.ReceiveTime.ToLocalTime()).TotalSeconds)} seconds.";
+                            log.Warn(_msg);
+                            HelperNotificationManager.Instance.AddNotification(this.Name, _msg,
+                                HelprNorificationManagerTypes.WARNING,
+                                HelprNorificationManagerCategories.PLUGINS);
+                        }
+
+                        // No buffer for this symbol = the plugin is mid-stop / mid-reconnect
+                        // (ClearAsync disposed and cleared the queues while the socket was still
+                        // delivering). Drop the frame. It must NOT fall through to the catch below:
+                        // that turned every in-flight delta into a reconnect request
+                        // (KeyNotFoundException storm observed in production on v0.1.11).
+                        if (!_eventBuffers.TryGetValue(normalizedSymbol, out var buffer))
+                            return; // Buffer was cleared during reconnection
+
+                        // The BOOK stamp is the venue's own event time (newest entry
+                        // "event_time", null when absent) — ReceiveTime stays the
+                        // freshness-warn input only, never the book stamp.
+                        buffer.Add(
+                            new Tuple<DateTime?, string, CoinbaseOrderBookUpdate>(
+                                ResolveBookTimestamp(data.Data), normalizedSymbol, data.Data));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    string _normalizedSymbol = "(null)";
+                    if (data != null && data.Data != null)
+                        _normalizedSymbol = GetNormalizedSymbol(data.Symbol);
+
+
+                    var _error =
+                        $"Will reconnect. Unhandled error while receiving delta market data for {_normalizedSymbol}.";
+                    LogException(ex, _error);
+                    Task.Run(async () => await HandleConnectionLost(_error, ex));
+                }
+            }
+        }
+
+        internal async Task InitializeSnapshotsAsync()
         {
             try
             {
@@ -406,6 +462,11 @@ namespace MarketConnectors.Coinbase
             catch (Exception ex)
             {
                 LogException(ex, "InitializeSnapshotsAsync");
+                // A failed snapshot must fail the start (same as a failed subscription) so the
+                // reconnection engine retries and, if it keeps failing, ends in STOPPED_FAILED.
+                // Swallowing it left every later symbol with no book and a paused delta consumer
+                // while the plugin reported CONNECTED; the trades consumer then threw per trade.
+                throw;
             }
         }
 
@@ -433,7 +494,7 @@ namespace MarketConnectors.Coinbase
             Task.Run(async () => await HandleConnectionLost(_error, ex));
         }
 
-        private void tradesBuffers_onReadAction(Tuple<string, CoinbaseTrade> item)
+        internal void tradesBuffers_onReadAction(Tuple<string, CoinbaseTrade> item)
         {
             var trade = tradePool.Get();
             trade.Price = item.Item2.Price;
@@ -443,7 +504,12 @@ namespace MarketConnectors.Coinbase
             trade.ProviderId = _settings.Provider.ProviderID;
             trade.ProviderName = _settings.Provider.ProviderName;
             trade.IsBuy = item.Item2.OrderSide == OrderSide.Buy;
-            trade.MarketMidPrice = _localOrderBooks[item.Item1] == null ? 0 : _localOrderBooks[item.Item1].MidPrice;
+            // The book can be ABSENT (ClearAsync emptied the map while trades were still queued),
+            // not only null (not loaded yet). Both stamp mid 0; an indexer here threw
+            // KeyNotFoundException into the queue's error action and requested a reconnect.
+            trade.MarketMidPrice = _localOrderBooks.TryGetValue(item.Item1, out var lob) && lob != null
+                ? lob.MidPrice
+                : 0;
 
             RaiseOnDataReceived(trade);
             tradePool.Return(trade);
@@ -805,11 +871,22 @@ namespace MarketConnectors.Coinbase
                 _disposed = true;
                 if (disposing)
                 {
-                    UnattachEventHandlers(deltaSubscription?.Data);
-                    UnattachEventHandlers(tradesSubscription?.Data);
-                    _socketClient?.UnsubscribeAllAsync();
-                    _socketClient?.Dispose();
-                    _restClient?.Dispose();
+                    // App-exit disposal reaches the same dead subscriptions ClearAsync now tolerates, so
+                    // it needs the same guard: a throw here would skip everything below - the ping timer,
+                    // the start/stop lock, the queues and the order books. Error, not Warn, for the reason
+                    // given in ClearAsync.
+                    try
+                    {
+                        UnattachEventHandlers(deltaSubscription?.Data);
+                        UnattachEventHandlers(tradesSubscription?.Data);
+                        _socketClient?.UnsubscribeAllAsync();
+                        _socketClient?.Dispose();
+                        _restClient?.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Error($"{this.Name}: teardown of the outgoing socket failed during dispose; continuing with local cleanup.", ex);
+                    }
                     _timerPing?.Dispose();
                     _startStopLock?.Dispose();
 

--- a/VisualHFT.Plugins/MarketConnectors.Coinbase/MarketConnectors.Coinbase.csproj
+++ b/VisualHFT.Plugins/MarketConnectors.Coinbase/MarketConnectors.Coinbase.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\..\VisualHFT.Commons\VisualHFT.Commons.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MarketConnectors.Coinbase.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/VisualHFT.Plugins/MarketConnectors.Kraken/KrakenPlugin.cs
+++ b/VisualHFT.Plugins/MarketConnectors.Kraken/KrakenPlugin.cs
@@ -5,6 +5,7 @@ using CryptoExchange.Net.Objects.Sockets;
 using Kraken.Net;
 using Kraken.Net.Clients;
 using Kraken.Net.Enums;
+using Kraken.Net.Interfaces.Clients;
 using Kraken.Net.Objects.Models;
 using Kraken.Net.Objects.Models.Socket;
 using MarketConnectors.Kraken.Model;
@@ -39,8 +40,8 @@ namespace MarketConnectors.Kraken
         private bool isReconnecting = false;
 
         private PlugInSettings _settings;
-        private KrakenSocketClient _socketClient;
-        private KrakenRestClient _restClient;
+        private IKrakenSocketClient _socketClient;
+        private IKrakenRestClient _restClient;
         // CONC-1: thread-safe — written on the WS snapshot path, read on the book + trades consumer threads.
         private readonly ConcurrentDictionary<string, VisualHFT.Model.OrderBook> _localOrderBooks = new();
         // ACC-1: per-symbol raw-DECIMAL mirror of the book, maintained solely to validate Kraken's v2 CRC32
@@ -95,24 +96,6 @@ namespace MarketConnectors.Kraken
         {
 
             await base.StartAsync();//call the base first
-            _socketClient = new KrakenSocketClient(options =>
-            {
-
-                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
-                {
-                    options.ApiCredentials = new KrakenCredentials() { Spot = new HMACCredential(_settings.ApiKey, _settings.ApiSecret) };
-                }
-                options.Environment = KrakenEnvironment.Live;
-            });
-
-            _restClient = new KrakenRestClient(options =>
-            {
-                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
-                {
-                    options.ApiCredentials = new KrakenCredentials() { Spot = new HMACCredential(_settings.ApiKey, _settings.ApiSecret) };
-                }
-                options.Environment = KrakenEnvironment.Live;
-            });
 
 
             try
@@ -130,6 +113,44 @@ namespace MarketConnectors.Kraken
             }
         }
         
+        /// <summary>Seam so a test can substitute the venue clients and observe their lifetime.</summary>
+        protected virtual IKrakenSocketClient CreateSocketClient()
+        {
+            return new KrakenSocketClient(options =>
+            {
+
+                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
+                {
+                    options.ApiCredentials = new KrakenCredentials() { Spot = new HMACCredential(_settings.ApiKey, _settings.ApiSecret) };
+                }
+                options.Environment = KrakenEnvironment.Live;
+            });
+        }
+
+        /// <summary>Seam so a test can substitute the venue clients and observe their lifetime.</summary>
+        protected virtual IKrakenRestClient CreateRestClient()
+        {
+            return new KrakenRestClient(options =>
+            {
+                if (_settings.ApiKey != "" && _settings.ApiSecret != "")
+                {
+                    options.ApiCredentials = new KrakenCredentials() { Spot = new HMACCredential(_settings.ApiKey, _settings.ApiSecret) };
+                }
+                options.Environment = KrakenEnvironment.Live;
+            });
+        }
+
+        internal void ReplaceClients()
+        {
+            // The previous clients are torn down by ClearAsync while still alive, then disposed and replaced here,
+            // under the start/stop lock, so a concurrent start cannot dispose a client another thread is subscribing on.
+            _socketClient?.Dispose();
+            _restClient?.Dispose();
+
+            _socketClient = CreateSocketClient();
+            _restClient = CreateRestClient();
+        }
+
         private async Task InternalStartAsync()
         {
             // ✅ FIX: Add synchronization
@@ -137,6 +158,7 @@ namespace MarketConnectors.Kraken
             try
             {
                 await ClearAsync();
+                ReplaceClients();
 
                 // Initialize event buffer for each symbol
                 foreach (var symbol in GetAllNormalizedSymbols())
@@ -172,20 +194,6 @@ namespace MarketConnectors.Kraken
                 Status = ePluginStatus.STOPPING;
                 log.Info($"{this.Name} is stopping.");
 
-                // ✅ FIX: Force cancel any pending reconnections by closing subscriptions first
-                foreach (var sub in deltaSubscriptions.Values)
-                {
-                    UnattachEventHandlers(sub?.Data);
-                    if (sub != null && sub.Data != null)
-                        await sub.Data.CloseAsync();
-                }
-                foreach (var sub in tradesSubscriptions.Values)
-                {
-                    UnattachEventHandlers(sub?.Data);
-                    if (sub != null && sub.Data != null)
-                        await sub.Data.CloseAsync();
-                }
-
                 await ClearAsync();
                 RaiseOnDataReceived(new List<VisualHFT.Model.OrderBook>());
                 RaiseOnDataReceived(GetProviderModel(eSESSIONSTATUS.DISCONNECTED));
@@ -200,10 +208,37 @@ namespace MarketConnectors.Kraken
 
         private async Task ClearAsync()
         {
-            // ✅ Subscription cleanup is done in StopAsync to prevent reconnection races
-            // Only unsubscribe here if not already done
-            if (_socketClient != null)
-                await _socketClient.UnsubscribeAllAsync();
+            // On the reconnect path the outgoing socket is by definition unhealthy; its teardown failing
+            // must not keep the dead client alive or strand StopAsync at STOPPING. The subscription
+            // teardown lives here rather than in StopAsync because BOTH stop paths - StopAsync and the
+            // reconnect's InternalStartAsync - must tear the subscriptions down on the live OUTGOING
+            // client and tolerate a dead one. Both maps are emptied further down, so a completed stop
+            // leaves no stale subscription behind.
+            // Error, not Warn: Telemetry/TelemetryAppender.cs sets Threshold = Level.Error, so a Warn
+            // never ships and a fleet-wide teardown failure would be invisible in production telemetry.
+            // Not LogException, which would also raise a user-facing notification for a condition this
+            // connector has already handled.
+            try
+            {
+                foreach (var sub in deltaSubscriptions.Values)
+                {
+                    UnattachEventHandlers(sub?.Data);
+                    if (sub != null && sub.Data != null)
+                        await sub.Data.CloseAsync();
+                }
+                foreach (var sub in tradesSubscriptions.Values)
+                {
+                    UnattachEventHandlers(sub?.Data);
+                    if (sub != null && sub.Data != null)
+                        await sub.Data.CloseAsync();
+                }
+                if (_socketClient != null)
+                    await _socketClient.UnsubscribeAllAsync();
+            }
+            catch (Exception ex)
+            {
+                log.Error($"{this.Name}: teardown of the outgoing socket failed; continuing with local cleanup.", ex);
+            }
                 
             _timerPing?.Stop();
             _timerPing?.Dispose();
@@ -889,20 +924,32 @@ namespace MarketConnectors.Kraken
                 _disposed = true;
                 if (disposing)
                 {
-                    foreach (var sub in deltaSubscriptions.Values)
-                        UnattachEventHandlers(sub?.Data);
-                    foreach (var sub in tradesSubscriptions.Values)
-                        UnattachEventHandlers(sub?.Data);
-                    
-                    // LIFE-4: wait (bounded) for the unsubscribe to actually complete before disposing the
-                    // socket client, instead of fire-and-forget which abandons the unsubscribe. Mirrors KuCoin.
+                    // App-exit disposal reaches the same dead subscriptions ClearAsync now tolerates, so
+                    // it needs the same guard: the LIFE-4 try below covers only the Wait, not the unattach
+                    // loops, and a throw there would skip everything after it - the ping timer, the
+                    // start/stop lock, the queues and the order books. Error, not Warn, for the reason
+                    // given in ClearAsync.
                     try
                     {
-                        _socketClient?.UnsubscribeAllAsync().Wait(TimeSpan.FromSeconds(5));
+                        foreach (var sub in deltaSubscriptions.Values)
+                            UnattachEventHandlers(sub?.Data);
+                        foreach (var sub in tradesSubscriptions.Values)
+                            UnattachEventHandlers(sub?.Data);
+
+                        // LIFE-4: wait (bounded) for the unsubscribe to actually complete before disposing the
+                        // socket client, instead of fire-and-forget which abandons the unsubscribe. Mirrors KuCoin.
+                        try
+                        {
+                            _socketClient?.UnsubscribeAllAsync().Wait(TimeSpan.FromSeconds(5));
+                        }
+                        catch (Exception) { /* best-effort during dispose */ }
+                        _socketClient?.Dispose();
+                        _restClient?.Dispose();
                     }
-                    catch (Exception) { /* best-effort during dispose */ }
-                    _socketClient?.Dispose();
-                    _restClient?.Dispose();
+                    catch (Exception ex)
+                    {
+                        log.Error($"{this.Name}: teardown of the outgoing socket failed during dispose; continuing with local cleanup.", ex);
+                    }
                     _timerPing?.Dispose();
 
                     // ✅ FIX: Dispose semaphore

--- a/VisualHFT.Plugins/MarketConnectors.Kraken/KrakenPlugin.cs
+++ b/VisualHFT.Plugins/MarketConnectors.Kraken/KrakenPlugin.cs
@@ -214,10 +214,10 @@ namespace MarketConnectors.Kraken
             // reconnect's InternalStartAsync - must tear the subscriptions down on the live OUTGOING
             // client and tolerate a dead one. Both maps are emptied further down, so a completed stop
             // leaves no stale subscription behind.
-            // Error, not Warn: Telemetry/TelemetryAppender.cs sets Threshold = Level.Error, so a Warn
+            // Error, not Warn: the desktop telemetry appender ships nothing below Error, so a Warn
             // never ships and a fleet-wide teardown failure would be invisible in production telemetry.
-            // Not LogException, which would also raise a user-facing notification for a condition this
-            // connector has already handled.
+            // Not LogException: it also increments OperationalErrorsCount, which the feed-health study
+            // reads as a feed failure, and a tolerated teardown is not one.
             try
             {
                 foreach (var sub in deltaSubscriptions.Values)

--- a/VisualHFT.Plugins/MarketConnectors.Kraken/MarketConnectors.Kraken.csproj
+++ b/VisualHFT.Plugins/MarketConnectors.Kraken/MarketConnectors.Kraken.csproj
@@ -46,4 +46,8 @@
     <ProjectReference Include="..\..\VisualHFT.Commons\VisualHFT.Commons.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MarketConnectors.Kraken.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Integration/VisualHFT.DataRetriever.Tests/ReconnectionEngineTests.cs
+++ b/tests/Integration/VisualHFT.DataRetriever.Tests/ReconnectionEngineTests.cs
@@ -1,0 +1,592 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VisualHFT.Commons.Helpers;
+using VisualHFT.Commons.PluginManager;
+using VisualHFT.Enums;
+using VisualHFT.Model;
+using VisualHFT.PluginManager;
+using VisualHFT.UserSettings;
+using Xunit;
+
+namespace VisualHFT.DataRetriever.TestingFramework.TestCases
+{
+    /// <summary>
+    /// Deterministic, offline tests for the SHARED reconnection engine in
+    /// BasePluginDataRetriever.HandleConnectionLost (attempt cap, exponential-backoff orchestration,
+    /// dedup/coalescing, terminal STOPPED_FAILED). Today this logic is only exercised by the live
+    /// PluginFunctionalTests via a flaky hack (throwing inside the global order-book callback). Here it
+    /// is driven against a minimal in-memory fake with the wall-clock backoff overridden to complete
+    /// instantly — so the same engine is proven without network or multi-second waits.
+    ///
+    /// The second block of tests covers the engine's POST-START DECISION: what the retry loop must
+    /// conclude from the status a connector's StartAsync leaves behind. That is where the engine is
+    /// currently blind — a connector reports a failed start by handing off to HandleConnectionLost from
+    /// inside its own catch (CoinbasePlugin.cs:123-128), the hand-off is swallowed by the re-entry guard
+    /// (BasePluginDataRetriever.cs:293) because the engine's own loop already owns the flag, StartAsync
+    /// then returns normally with Status still STARTING, and the loop declares success and stamps
+    /// STARTED unconditionally (:397-401). A half-started plugin reads as green.
+    ///
+    /// The third block covers three defects in that post-start outcome rule, each named DEFECT 1/2/3 on
+    /// its test: an external stop (the user flipping the provider rail off) is retried as a failure, a
+    /// forced restart overrides the connector's own terminal STOPPED_FAILED verdict, and the engine runs
+    /// the connector's internal start TWICE per attempt (once itself, once inside StartAsync).
+    ///
+    /// NOTE: this covers the engine ORCHESTRATION. The per-connector "reconnect re-seeds the book"
+    /// assertion is covered separately (SimulateConnectionInterruption on each real connector), because
+    /// a real connector's StartAsync re-opens the live socket and cannot complete a reconnect offline.
+    /// </summary>
+    public class ReconnectionEngineTests
+    {
+        // Mirrors the private const in BasePluginDataRetriever; asserted explicitly so a change to the
+        // cap is a deliberate, visible test update.
+        private const int MaxReconnectionAttempts = 5;
+
+        /// <summary>
+        /// The five ways a connector's StartAsync actually ends in this codebase. The engine has to tell
+        /// them apart — only one of them is a successful reconnection.
+        /// </summary>
+        private enum StartOutcome
+        {
+            /// <summary>Clean start: Status = STARTED (every healthy connector, e.g. CoinbasePlugin.cs:119).</summary>
+            Started,
+
+            /// <summary>
+            /// The venue work threw and the connector's own catch handed the failure to the engine
+            /// (CoinbasePlugin.cs:123-128). Status is left where base.StartAsync() put it: STARTING.
+            /// </summary>
+            FailLikeRealConnector,
+
+            /// <summary>
+            /// The plugin deliberately declined to start and stayed idle: Status = LOADED
+            /// (ReplayEnginePlugin.cs:617-624 — no configured session).
+            /// </summary>
+            LeaveLoaded,
+
+            /// <summary>The start concluded it had failed terminally: Status = STOPPED_FAILED.</summary>
+            StoppedFailed,
+
+            /// <summary>
+            /// Somebody stopped the plugin while it was starting: Status = STOPPED. The provider rail
+            /// does exactly this on a user toggle-off — StopAsync() then a force-set of the status on a
+            /// plugin still in STARTING (vmProviderRail.cs:305-311).
+            /// </summary>
+            LeaveStopped
+        }
+
+        [Fact]
+        public async Task Reconnect_WhenActionSucceeds_TransitionsToStarted()
+        {
+            var fake = new ReconnectEngineFake();
+
+            await fake.TriggerReconnect(force: true);
+
+            Assert.Equal(ePluginStatus.STARTED, fake.Status);
+            Assert.True(fake.ReconnectActionCallCount >= 1, "reconnect action should run at least once");
+            Assert.True(fake.StartAsyncCallCount >= 1, "StartAsync should be invoked on a successful attempt");
+        }
+
+        [Fact]
+        public async Task Reconnect_WhenEveryAttemptFails_ExhaustsCapThenStoppedFailed()
+        {
+            var fake = new ReconnectEngineFake { ShouldFail = true };
+
+            await fake.TriggerReconnect(force: true);
+
+            Assert.Equal(ePluginStatus.STOPPED_FAILED, fake.Status);
+            // The engine must retry exactly up to the cap before giving up — no infinite loop, no early give-up.
+            Assert.Equal(MaxReconnectionAttempts, fake.ReconnectActionCallCount);
+            // CHANGED (DEFECT 3): this used to assert StartAsyncCallCount == 0, which only held because the
+            // engine invoked the registered action ITSELF (BasePluginDataRetriever.cs:378-381) and the throw
+            // escaped before StartAsync was ever reached — i.e. the old assertion encoded the double-call
+            // design. With the fake faithful to real connectors (StartAsync awaits the internal start, as
+            // BinancePlugin.cs:89 does), one attempt is one StartAsync that fails from the inside, so both
+            // counts must equal the cap.
+            Assert.Equal(MaxReconnectionAttempts, fake.StartAsyncCallCount);
+        }
+
+        [Fact]
+        public async Task Reconnect_ConcurrentCalls_AreCoalescedIntoOne()
+        {
+            var fake = new ReconnectEngineFake();
+            var actionEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Hold the first reconnection in-flight so its dedup flag is set when the second call arrives.
+            // The gate lives in the reconnect action, which the faithful fake now reaches from INSIDE
+            // StartAsync; either way it fires while HandleConnectionLost owns the dedup flag (:293).
+            fake.GateBeforeAction = async () =>
+            {
+                actionEntered.TrySetResult();
+                await release.Task;
+            };
+
+            var first = fake.TriggerReconnect(force: true);
+            await actionEntered.Task;                       // first reconnection is now inside the engine
+
+            await fake.TriggerReconnect(force: true);       // must coalesce (return immediately), not start a 2nd
+
+            release.SetResult();
+            await first;
+
+            // Only the first reconnection ran; the concurrent one was dropped by the atomic dedup flag.
+            // Counted on StartAsync (one call == one attempt) rather than on the action, because the number
+            // of action calls per attempt is exactly what DEFECT 3 is about and is pinned by its own test.
+            Assert.Equal(1, fake.StartAsyncCallCount);
+            Assert.Equal(ePluginStatus.STARTED, fake.Status);
+        }
+
+        /// <summary>
+        /// THE ENGINE HOLE. A real connector signals a failed start by calling HandleConnectionLost from
+        /// its own catch block; inside the engine's retry loop that call is a no-op (the re-entry guard at
+        /// BasePluginDataRetriever.cs:293 already owns the flag), so StartAsync returns normally with
+        /// Status = STARTING. That is a FAILED attempt: the loop must retry it, up to the cap, and end in
+        /// STOPPED_FAILED — never stamp STARTED over a plugin that never started.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_WhenStartAsyncFailsLikeARealConnector_IsRetriedUpToCapThenStoppedFailed()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.FailLikeRealConnector };
+
+            await fake.TriggerReconnect(force: true);
+
+            Assert.Equal(ePluginStatus.STOPPED_FAILED, fake.Status);
+            Assert.Equal(MaxReconnectionAttempts, fake.StartAsyncCallCount);
+            // One attempt runs the connector's internal start exactly once, so the two counts match
+            // (DEFECT 3: today the engine invokes the action itself as well, making this 2x StartAsync).
+            Assert.Equal(MaxReconnectionAttempts, fake.ReconnectActionCallCount);
+            // A plugin that never started must never have been announced as CONNECTED.
+            Assert.Equal(0, fake.ConnectedNotificationCount);
+        }
+
+        /// <summary>
+        /// The recovery path the hole also hides: two failed starts followed by a clean one is a
+        /// successful reconnection on the THIRD attempt, not on the first.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_WhenStartAsyncFailsTwiceThenSucceeds_EndsStartedAfterThreeAttempts()
+        {
+            var fake = new ReconnectEngineFake();
+            fake.EnqueueStartOutcomes(
+                StartOutcome.FailLikeRealConnector,
+                StartOutcome.FailLikeRealConnector,
+                StartOutcome.Started);
+
+            await fake.TriggerReconnect(force: true);
+
+            Assert.Equal(ePluginStatus.STARTED, fake.Status);
+            Assert.Equal(3, fake.StartAsyncCallCount);
+            // Same one-internal-start-per-attempt rule as above (DEFECT 3): today this is 6, not 3.
+            Assert.Equal(3, fake.ReconnectActionCallCount);
+            // CONNECTED is announced once — on the attempt that actually started, not on the failed ones.
+            Assert.Equal(1, fake.ConnectedNotificationCount);
+        }
+
+        /// <summary>
+        /// A plugin may decline to start on purpose and stay LOADED (ReplayEnginePlugin.cs:617-624, no
+        /// configured session — deliberately NOT presented as a connected feed). Retrying that is
+        /// pointless and overwriting its status is a lie: the loop must stop and leave LOADED alone.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_WhenStartAsyncLeavesLoaded_StopsWithoutMarkingStartedAndRaisesNoConnected()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.LeaveLoaded };
+
+            await fake.TriggerReconnect(force: true);
+
+            Assert.Equal(ePluginStatus.LOADED, fake.Status);
+            Assert.Equal(1, fake.StartAsyncCallCount);
+            Assert.DoesNotContain(eSESSIONSTATUS.CONNECTED, fake.ProviderStatuses);
+        }
+
+        /// <summary>
+        /// Regression guard for the one post-start branch the engine already gets right: an unforced
+        /// reconnection whose start reports STOPPED_FAILED gives up immediately. Expected GREEN before
+        /// the fix as well as after — it pins the behaviour the fix must not break.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_WhenStartAsyncReportsStoppedFailed_GivesUpWithoutForce()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.StoppedFailed };
+            // The unforced entry guard (BasePluginDataRetriever.cs:303-316) skips reconnection outright
+            // when Status is already STOPPED_FAILED/STOPPING, so start from a running plugin.
+            fake.Status = ePluginStatus.STARTED;
+
+            // Giving up is NOT a failed attempt: the loop must exit without routing the STOPPED_FAILED
+            // result through its failure path (which logs "Reconnection failed. Attempt N" and notifies the UI).
+            var failedAttemptNotifications = await CaptureFailedAttemptNotificationsAsync(
+                fake.Name, () => fake.TriggerReconnect(force: false));
+
+            Assert.Equal(ePluginStatus.STOPPED_FAILED, fake.Status);
+            Assert.Equal(1, fake.StartAsyncCallCount);
+            Assert.Equal(0, fake.ConnectedNotificationCount);
+            Assert.True(failedAttemptNotifications.Count == 0,
+                "an unforced STOPPED_FAILED result must exit the loop directly, not be counted as a failed attempt: " + string.Join(" | ", failedAttemptNotifications));
+            // The rail shows the LAST provider status announced. Giving up must announce the terminal
+            // failure, otherwise the tile keeps whatever the venue library announced last (Gemini's own
+            // reconnect handler announces CONNECTED right before stamping STOPPED_FAILED,
+            // GeminiPlugin.cs:202-208): a green tile on a dead feed.
+            Assert.Equal(eSESSIONSTATUS.DISCONNECTED_FAILED, fake.ProviderStatuses.Last());
+        }
+
+        /// <summary>
+        /// The give-up exit resets the attempt counter. Without the reset, every settings-dialog reload
+        /// (a forced reconnect) on a connector that keeps reporting STOPPED_FAILED leaves the count
+        /// standing; after five such reloads the retry loop's while-condition is false on entry and the
+        /// sixth reload runs no start at all — silently. Six forced reloads must run six starts.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_RepeatedForcedReloads_OnAConnectorThatKeepsGivingUp_EachRunTheStart()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.StoppedFailed };
+
+            for (int reload = 0; reload < MaxReconnectionAttempts + 1; reload++)
+            {
+                await fake.TriggerReconnect(force: true);
+            }
+
+            Assert.Equal(MaxReconnectionAttempts + 1, fake.StartAsyncCallCount);
+            Assert.Equal(ePluginStatus.STOPPED_FAILED, fake.Status);
+        }
+
+        /// <summary>
+        /// The retry loop's backoff must go through the ReconnectBackoffDelayAsync seam
+        /// (BasePluginDataRetriever.cs:279) that exists for exactly this purpose. It currently awaits
+        /// Task.Delay directly (:362), so the seam override is dead and a full-cap engine test sleeps for
+        /// ~62s of real wall clock (2+4+8+16+32s plus jitter).
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_BackoffGoesThroughTheOverridableSeam_OnEveryAttempt()
+        {
+            var fake = new ReconnectEngineFake { ShouldFail = true };
+
+            var stopwatch = Stopwatch.StartNew();
+            await fake.TriggerReconnect(force: true);
+            stopwatch.Stop();
+
+            // Structural, not wall-clock: every attempt's delay must be the seam call. (A bypassed seam
+            // would show as a missing call here; the hang guard below only catches a real-clock backoff.)
+            Assert.Equal(MaxReconnectionAttempts, fake.BackoffDelayCallCount);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(30),
+                $"the {MaxReconnectionAttempts}-attempt cap under an overridden backoff took {stopwatch.Elapsed.TotalSeconds:F1}s — a real-clock backoff leaked in");
+            Assert.Equal(ePluginStatus.STOPPED_FAILED, fake.Status);
+        }
+
+        /// <summary>
+        /// DEFECT 1 — an external stop is retried as if it were a failed connection attempt.
+        /// Mid-reconnect the user flips the provider rail OFF: vmProviderRail.cs:305-311 calls the
+        /// retriever's StopAsync() directly and force-sets Status = STOPPED on a plugin that is still
+        /// STARTING. The retry loop's final else (BasePluginDataRetriever.cs:419-421) reads STOPPED as
+        /// "the attempt did not reach STARTED", throws, and retries to the cap — ~62s of real backoff
+        /// (2+4+8+16+32s), 6 ERROR notifications, and a plugin the USER stopped on purpose left in
+        /// STOPPED_FAILED, which the unforced entry guard (:303-316) then refuses to restart.
+        ///
+        /// Target rule: after the retried StartAsync, only STARTING — the status base.StartAsync()
+        /// stamps at :67 and that a connector's own failure hand-off leaves behind — is a failed
+        /// attempt. STOPPED or STOPPING means somebody stopped the plugin: exit the loop, retry
+        /// nothing, mark nothing, notify nothing.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_WhenStartAsyncLeavesStopped_ExitsWithoutRetryingOrMarking()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.LeaveStopped };
+
+            var failedAttemptNotifications = await CaptureFailedAttemptNotificationsAsync(
+                fake.Name, () => fake.TriggerReconnect(force: true));
+
+            Assert.Equal(ePluginStatus.STOPPED, fake.Status);
+            Assert.Equal(1, fake.StartAsyncCallCount);
+            // Nothing started, so nothing may be announced as connected.
+            Assert.Equal(0, fake.ConnectedNotificationCount);
+            Assert.True(failedAttemptNotifications.Count == 0,
+                "a plugin stopped externally must not be counted as a failed reconnection attempt: " + string.Join(" | ", failedAttemptNotifications));
+            // The exit must leave the tile consistent with the status it is honouring (base.StartAsync
+            // announced CONNECTING moments earlier; a stopped plugin must read as disconnected).
+            Assert.Equal(eSESSIONSTATUS.DISCONNECTED, fake.ProviderStatuses.Last());
+        }
+
+        /// <summary>
+        /// DEFECT 2 — a forced restart overrides the connector's own terminal verdict.
+        /// The STOPPED_FAILED exit at BasePluginDataRetriever.cs:413 is gated on
+        /// !forceStartRegardlessStatus, so with force:true a start that reported STOPPED_FAILED falls
+        /// through to the throw at :421 and is retried 5 times. Binance and Gemini set STOPPED_FAILED
+        /// deliberately and WITHOUT retry on a [CantConnectError] (BinancePlugin.cs:95-103,
+        /// GeminiPlugin.cs:95-97) — and every settings-dialog reload enters the engine with force:true.
+        ///
+        /// Target rule: force only bypasses the ENTRY guard (:303-316), so a previously failed plugin
+        /// can be restarted at all. STOPPED_FAILED reported *by the start itself* is the connector
+        /// giving up: honour it immediately, forced or not.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_ForcedRestart_WhenStartReportsStoppedFailed_GivesUpImmediately()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.StoppedFailed };
+
+            var failedAttemptNotifications = await CaptureFailedAttemptNotificationsAsync(
+                fake.Name, () => fake.TriggerReconnect(force: true));
+
+            Assert.Equal(ePluginStatus.STOPPED_FAILED, fake.Status);
+            Assert.Equal(1, fake.StartAsyncCallCount);
+            Assert.Equal(0, fake.ConnectedNotificationCount);
+            Assert.True(failedAttemptNotifications.Count == 0,
+                "a start that reported STOPPED_FAILED must end the loop even when forced, not be retried to the cap: " + string.Join(" | ", failedAttemptNotifications));
+            // Same terminal announcement as the unforced give-up: the tile must not keep a stale status.
+            Assert.Equal(eSESSIONSTATUS.DISCONNECTED_FAILED, fake.ProviderStatuses.Last());
+        }
+
+        /// <summary>
+        /// DEFECT 3 — the engine runs the connector's internal start TWICE per attempt.
+        /// The loop invokes the registered action itself (BasePluginDataRetriever.cs:378-381) and then
+        /// calls StartAsync() (:386) — and every connector registers its InternalStartAsync
+        /// (BinancePlugin.cs:72, BitfinexPlugin.cs:64, BitStampPlugin.cs:65, CoinbasePlugin.cs:76,
+        /// GeminiPlugin.cs:74, KrakenPlugin.cs:86, KuCoinPlugin.cs:89) and then awaits that same method
+        /// again from inside its own StartAsync (BinancePlugin.cs:89, BitfinexPlugin.cs:95,
+        /// CoinbasePlugin.cs:114, KrakenPlugin.cs:120, KuCoinPlugin.cs:144, BitStampPlugin.cs:79,
+        /// GeminiPlugin.cs:89). One reconnection attempt therefore fires two full subscribe bursts
+        /// milliseconds apart against the venue, and it is the SECOND one whose status decides the
+        /// attempt.
+        ///
+        /// Target rule: one attempt = one StartAsync() call. SetReconnectionAction (:268) stays as a
+        /// registration API, but the engine no longer invokes the action itself — the connector's own
+        /// start is what performs the internal start.
+        /// </summary>
+        [Fact]
+        public async Task Reconnect_RunsTheConnectorStartOncePerAttempt_NeverTheActionSeparately()
+        {
+            var fake = new ReconnectEngineFake { DefaultStartOutcome = StartOutcome.Started };
+
+            await fake.TriggerReconnect(force: true);
+
+            Assert.Equal(ePluginStatus.STARTED, fake.Status);
+            Assert.Equal(1, fake.StartAsyncCallCount);
+            // Today this is 2: the engine's own invoke plus the one inside StartAsync.
+            Assert.Equal(1, fake.ReconnectActionCallCount);
+        }
+
+        /// <summary>
+        /// Captures the engine's failed-attempt notifications — "Reconnection failed. Attempt N of M",
+        /// raised through LogException(..., NotifyToUI: true) at BasePluginDataRetriever.cs:426-427 —
+        /// for the duration of one reconnection, so a test can prove an outcome was NOT counted as a
+        /// failed attempt. HelperNotificationManager raises NotificationAdded synchronously
+        /// (HelperNotificationManager.cs:72,175), so everything the run notified is captured by the
+        /// time the awaited reconnection returns.
+        /// </summary>
+        private static async Task<IReadOnlyList<string>> CaptureFailedAttemptNotificationsAsync(string pluginName, Func<Task> reconnection)
+        {
+            var captured = new ConcurrentBag<string>();
+            EventHandler<ErrorNotificationEventArgs> onNotification = (_, e) =>
+            {
+                var message = e.Notification.Message;
+                if (message != null
+                    && message.Contains(pluginName, StringComparison.Ordinal)
+                    && message.Contains("Reconnection failed", StringComparison.Ordinal))
+                {
+                    captured.Add(message);
+                }
+            };
+
+            HelperNotificationManager.Instance.NotificationAdded += onNotification;
+            try
+            {
+                await reconnection();
+            }
+            finally
+            {
+                HelperNotificationManager.Instance.NotificationAdded -= onNotification;
+            }
+
+            return captured.ToList();
+        }
+
+        // ----------------------------------------------------------------------------------------
+        // Minimal concrete BasePluginDataRetriever for driving the base-class reconnection engine.
+        // It implements the abstract surface with no-ops and controls the reconnect outcome in-memory.
+        // ----------------------------------------------------------------------------------------
+        private sealed class ReconnectEngineFake : BasePluginDataRetriever
+        {
+            // Field initializer runs BEFORE the base constructor, so LoadSettings() (called from the
+            // base ctor) can already see it.
+            private readonly Provider _provider = new Provider { ProviderID = 4242, ProviderName = "RECONNECT_FAKE" };
+            private readonly Queue<StartOutcome> _startOutcomes = new Queue<StartOutcome>();
+            private readonly ConcurrentQueue<eSESSIONSTATUS> _providerStatuses = new ConcurrentQueue<eSESSIONSTATUS>();
+
+            public bool ShouldFail { get; set; }
+            public int ReconnectActionCallCount;
+            public int StartAsyncCallCount;
+            public int BackoffDelayCallCount;
+            public Func<Task> GateBeforeAction;
+
+            /// <summary>How StartAsync ends once the per-attempt queue is exhausted.</summary>
+            public StartOutcome DefaultStartOutcome { get; set; } = StartOutcome.Started;
+
+            /// <summary>Provider statuses announced through the base class, in order.</summary>
+            public IReadOnlyList<eSESSIONSTATUS> ProviderStatuses => _providerStatuses.ToList();
+
+            /// <summary>How many CONNECTED announcements the ENGINE made (see the note in StartAsync).</summary>
+            public int ConnectedNotificationCount => _providerStatuses.Count(status => status == eSESSIONSTATUS.CONNECTED);
+
+            public ReconnectEngineFake()
+            {
+                // Registered exactly as every connector registers its own InternalStartAsync
+                // (BinancePlugin.cs:72, CoinbasePlugin.cs:76, KrakenPlugin.cs:86, ...).
+                SetReconnectionAction(ReconnectActionAsync);
+            }
+
+            /// <summary>Queues per-attempt StartAsync outcomes, consumed in order.</summary>
+            public void EnqueueStartOutcomes(params StartOutcome[] outcomes)
+            {
+                foreach (var outcome in outcomes)
+                {
+                    _startOutcomes.Enqueue(outcome);
+                }
+            }
+
+            private StartOutcome NextStartOutcome()
+            {
+                lock (_startOutcomes)
+                {
+                    return _startOutcomes.Count > 0 ? _startOutcomes.Dequeue() : DefaultStartOutcome;
+                }
+            }
+
+            /// <summary>
+            /// The connector's internal start: the subscribe burst that opens the venue socket. It is both
+            /// the method registered with SetReconnectionAction AND the one the connector's own StartAsync
+            /// awaits — one object, two call sites in production, which is why counting its invocations
+            /// measures how many subscribe bursts one reconnection attempt actually fires.
+            /// </summary>
+            private async Task ReconnectActionAsync()
+            {
+                Interlocked.Increment(ref ReconnectActionCallCount);
+                if (GateBeforeAction != null)
+                {
+                    await GateBeforeAction();
+                }
+                if (ShouldFail)
+                {
+                    throw new InvalidOperationException("Synthetic offline reconnect failure.");
+                }
+            }
+
+            public Task TriggerReconnect(bool force) => HandleConnectionLost("test interruption", null, force);
+
+            // Make the retry loop's backoff instant so the engine orchestration is deterministic and fast.
+            protected override Task ReconnectBackoffDelayAsync(int milliseconds)
+            {
+                Interlocked.Increment(ref BackoffDelayCallCount);
+                return Task.CompletedTask;
+            }
+
+            /// <summary>
+            /// Same shape as every real connector: base first (which raises CONNECTING and sets STARTING),
+            /// then the connector's OWN internal start inside a try/catch, then one of the five endings.
+            /// The status this leaves behind is the only thing the engine can read, so the fake must set
+            /// it exactly like production does.
+            ///
+            /// The internal start here is the very method registered with SetReconnectionAction — that is
+            /// how every real connector is wired (e.g. BinancePlugin.cs:72 registers InternalStartAsync
+            /// and BinancePlugin.cs:89 awaits it from StartAsync), and reproducing it is what makes the
+            /// engine's separate invoke of the same action (BasePluginDataRetriever.cs:378-381) visible as
+            /// the double subscribe burst it is.
+            /// </summary>
+            public override async Task StartAsync()
+            {
+                Interlocked.Increment(ref StartAsyncCallCount);
+                await base.StartAsync();
+
+                var outcome = NextStartOutcome();
+                switch (outcome)
+                {
+                    case StartOutcome.Started:
+                    case StartOutcome.FailLikeRealConnector:
+                        try
+                        {
+                            await ReconnectActionAsync();
+                            if (outcome == StartOutcome.FailLikeRealConnector)
+                            {
+                                await FailingVenueStartAsync();
+                            }
+
+                            // Real connectors also announce CONNECTED here (CoinbasePlugin.cs:118). The
+                            // fake deliberately does not, so ConnectedNotificationCount counts only what
+                            // the ENGINE announced — otherwise the production duplicate would mask the
+                            // engine's own.
+                            Status = ePluginStatus.STARTED;
+                        }
+                        catch (Exception ex)
+                        {
+                            // CoinbasePlugin.cs:123-128 verbatim: log, then hand the failure to the engine.
+                            // Inside the engine's own loop that hand-off is swallowed, and Status stays STARTING.
+                            var error = ex.Message;
+                            LogException(ex, error);
+                            await HandleConnectionLost(error, ex);
+                        }
+                        break;
+
+                    case StartOutcome.LeaveLoaded:
+                        Status = ePluginStatus.LOADED;
+                        break;
+
+                    case StartOutcome.StoppedFailed:
+                        Status = ePluginStatus.STOPPED_FAILED;
+                        break;
+
+                    case StartOutcome.LeaveStopped:
+                        // vmProviderRail.cs:309-310 verbatim: on a user toggle-off of a plugin that is
+                        // still STARTING, the rail calls the retriever's StopAsync() directly and then
+                        // force-sets the status. No further internal start work runs.
+                        await StopAsync();
+                        Status = ePluginStatus.STOPPED;
+                        break;
+                }
+            }
+
+            private static Task FailingVenueStartAsync()
+            {
+                throw new InvalidOperationException("Synthetic start failure (venue unreachable).");
+            }
+
+            /// <summary>
+            /// BasePluginDataRetriever exposes no data-received event (the one in
+            /// RaiseOnDataReceived(DataEventArgs) is commented out at :96), so this protected virtual
+            /// raise method IS the observation seam for provider status notifications.
+            /// </summary>
+            protected override void RaiseOnDataReceived(Provider heartBeatModel, bool overrideDisabiityFromOtherDataRetrievers = false)
+            {
+                if (heartBeatModel != null)
+                {
+                    _providerStatuses.Enqueue(heartBeatModel.Status);
+                }
+                base.RaiseOnDataReceived(heartBeatModel, overrideDisabiityFromOtherDataRetrievers);
+            }
+
+            // Faithful to production: the engine's StopAsync() step leaves STOPPED (base sets it) before
+            // the retried StartAsync stamps STARTING again.
+            public override Task StopAsync() => base.StopAsync();
+
+            public override string Name { get; set; } = "ReconnectEngineFake";
+            public override string Version { get; set; } = "1.0";
+            public override string Description { get; set; } = "test fake";
+            public override string Author { get; set; } = "test";
+            public override ISetting Settings { get; set; }
+            public override Action CloseSettingWindow { get; set; }
+
+            protected override void LoadSettings() => Settings = new FakeSetting(_provider);
+            protected override void SaveSettings() { }
+            protected override void InitializeDefaultSettings() { }
+            public override object GetUISettings() => null;
+        }
+
+        private sealed class FakeSetting : ISetting
+        {
+            public FakeSetting(Provider provider) => Provider = provider;
+            public string Symbol { get; set; } = "TESTUSD";
+            public Provider Provider { get; set; }
+            public AggregationLevel AggregationLevel { get; set; }
+        }
+    }
+}

--- a/tests/Unit/VisualHFT.Commons.Tests/OrderBookDisposedGuardTests.cs
+++ b/tests/Unit/VisualHFT.Commons.Tests/OrderBookDisposedGuardTests.cs
@@ -1,0 +1,779 @@
+using System.Diagnostics;
+using System.Reflection;
+using VisualHFT.Commons.Model;
+using VisualHFT.Model;
+
+namespace VisualHFT.Commons.Tests;
+
+/// <summary>
+/// DEFECT B — a disposed <see cref="OrderBook"/> still throws on the mutation entry points the
+/// connectors reach INLINE from the socket thread, so a book disposed by a reconnect turns the very
+/// next in-flight frame into a NullReferenceException.
+///
+/// The read side is already guarded: <c>GetBidsSnapshot</c> (VisualHFT.Commons/Model/OrderBook.cs:155),
+/// <c>GetAsksSnapshot</c> (OrderBook.cs:192) and <c>CalculateMetrics</c> (OrderBook.cs:307) all bail on
+/// <c>Volatile.Read(ref _disposed)</c> and return empty rather than throw. <c>DeleteLevel(..)</c>
+/// (OrderBook.cs:824) is the write-side PRECEDENT, not a defect: it already re-checks the side list for
+/// null INSIDE the write lock (OrderBook.cs:834-837 and :844-847) and returns, and it did so before
+/// this branch. <c>CalculateMetrics</c> does the same at OrderBook.cs:314. The remaining write paths do
+/// not:
+///   * <c>Clear()</c>              OrderBook.cs:630 -> InternalClear() -> <c>_data.Asks.Count()</c> (:434)
+///   * <c>AddOrUpdateLevel(..)</c> OrderBook.cs:656 -> <c>_list.Count()</c> on the null side list (:676)
+///   * <c>AddLevel(..)</c>         OrderBook.cs:699 -> <c>list.Count()</c> on the null side list (:717)
+///   * <c>UpdateLevel(..)</c>      OrderBook.cs:776 -> <c>.Update(..)</c> on the null side list (:786)
+/// while <c>OrderBookData.Dispose</c> (VisualHFT.Commons/Model/OrderBookData.cs:244-262) nulls
+/// <c>_Bids</c>/<c>_Asks</c> under the write lock.
+///
+/// DEFECT C — the sibling sweep stopped short. Three more entry points take the SAME write lock and
+/// dereference the SAME side lists with no guard of any kind, neither a <c>_disposed</c> pre-check nor
+/// an in-lock re-check:
+///   * <c>Reset()</c>          OrderBook.cs:649 -> InternalClear() -> <c>_data.Asks.Count()</c> (:434)
+///   * <c>UpdateSnapshot(..)</c> OrderBook.cs:466 -> <c>_data.Clear()</c> (:471) -> <c>foreach (var item in _Asks)</c> (OrderBookData.cs:202)
+///   * <c>LoadData(..)</c>     OrderBook.cs:320 -> <c>_data.Clear()</c> (:325) -> the same OrderBookData.cs:202
+/// These are not exotic paths: <c>LoadData</c> and <c>UpdateSnapshot</c> are how a REST or websocket
+/// SNAPSHOT is applied, which is precisely what a reconnect does immediately after the book map was
+/// torn down, and <c>Reset()</c> is the recycle path. The fix is the one-line in-lock re-check the
+/// other four now carry.
+///
+/// TWO defects live here, and they need two shapes of test.
+///
+/// (1) SEQUENTIAL — one thread, dispose then mutate. <c>Clear()</c> and <c>AddOrUpdateLevel(..)</c>
+/// answer this today via their <c>Volatile.Read(ref _disposed)</c> pre-check; <c>DeleteLevel</c> answers
+/// it via its in-lock null re-check. Pinned by the four <c>_OnADisposedBook_</c> tests below.
+///
+/// (2) THE RACE — the pre-check is check-then-act OUTSIDE the lock. A socket thread reads
+/// <c>_disposed == false</c>, is descheduled, and a reconnect thread runs
+/// <c>OrderBookData.Dispose</c>: flag set, write lock taken, <c>_Bids</c>/<c>_Asks</c> nulled, lock
+/// released. The socket thread resumes PAST its own guard, takes the write lock and dereferences null.
+/// A pre-lock flag read cannot close that window — only a null re-check INSIDE the lock can, which is
+/// exactly what <c>DeleteLevel</c> and <c>CalculateMetrics</c> already do. <c>AddLevel</c> and
+/// <c>UpdateLevel</c> are worse still: they carry no guard at all and are called directly on possibly
+/// disposed books by CoinbaseL3 (MarketConnectors.CoinbaseL3/CoinbasePlugin.cs:688, :701, :1021, :1034)
+/// and ReplayEngine (MarketConnectors.ReplayEngine/ReplayEnginePlugin.cs:1296, :1309).
+///
+/// The four <c>_WhenTheDisposeLandsAfterTheGuardPassed_</c> tests reproduce that window
+/// deterministically, without threads: dispose the book for real (side lists null, flag true), then put
+/// the private <c>_disposed</c> flag back to <c>false</c> by reflection. That is precisely the state a
+/// thread which has already passed the pre-check observes, and it is unreachable by any pre-lock flag
+/// read — so only an in-lock null re-check on all four write paths turns these green.
+///
+/// Why it matters here: Bitfinex applies snapshot and delta frames inline on the socket thread
+/// (<c>BitfinexPlugin.UpdateOrderBookSnapshot</c> -> <c>lob.Clear()</c> then <c>AddOrUpdateLevel</c>),
+/// and <c>ClearAsync</c> disposes every book in <c>_localOrderBooks</c> during a reconnect. The
+/// exception type and message shape produced by that window are identical to the production storm
+/// measured on v0.1.11 (309 error events, 2 users) — "Unhandled error while receiving delta market
+/// data for BTC/USD" with a NullReferenceException.
+///
+/// Contract under test: every mutation entry point behaves like the read side — a book whose side lists
+/// are gone silently ignores the frame (no throw, no state change), whether the caller learned that
+/// before or after it passed the guard, while a LIVE book still applies all of them.
+/// </summary>
+public class OrderBookDisposedGuardTests
+{
+    private const string Symbol = "BTC/USD";
+    private const int PriceDecimalPlaces = 2;
+    private const int MaxDepth = 25;
+
+    /// <summary>Ceiling on waiting for the mutation thread to park on the write lock (normally microseconds).</summary>
+    private static readonly TimeSpan ParkTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Ceiling on the mutation finishing once the lock is handed over; a miss means a deadlock.</summary>
+    private static readonly TimeSpan JoinTimeout = TimeSpan.FromSeconds(5);
+
+    // ---------------------------------------------------------------------------------------------
+    // (1) SEQUENTIAL — the caller can see the disposed flag before it acts.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_OnADisposedBook_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+        book.Dispose();
+
+        Exception? thrown = Record.Exception(() => book.Clear());
+
+        Assert.True(thrown == null,
+            "Clear() on a disposed book must be a no-op (the read side already bails on _disposed). "
+            + "It threw instead, which is exactly the shape of the Bitfinex production storm: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void AddOrUpdateLevel_OnADisposedBook_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+        book.Dispose();
+
+        Exception? thrown = Record.Exception(() => book.AddOrUpdateLevel(Delta(isBid: true, price: 100.5, size: 2.0)));
+
+        Assert.True(thrown == null,
+            "AddOrUpdateLevel() on a disposed book must be a no-op; a delta frame in flight when "
+            + "ClearAsync disposes the book reaches this line inline on the socket thread. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void DeleteLevel_OnADisposedBook_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+        book.Dispose();
+
+        Exception? thrown = Record.Exception(() => book.DeleteLevel(Delta(isBid: true, price: 100.5, size: 0.0)));
+
+        Assert.True(thrown == null,
+            "DeleteLevel() on a disposed book must be a no-op; a delta frame in flight when "
+            + "ClearAsync disposes the book reaches this line inline on the socket thread. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void MutationsOnADisposedBook_LeaveItEmpty_NotPartiallyMutated()
+    {
+        // The guard must DROP the frame, not half-apply it: a disposed book has no side lists left,
+        // so the only correct outcome is "nothing happened".
+        //
+        // NOTE — there is deliberately no post-state assertion here. GetBidsSnapshot/GetAsksSnapshot
+        // return 0 UNCONDITIONALLY on a disposed book (OrderBook.cs:160-161, :195-196, the _disposed
+        // pre-check), and _data.Bids/_data.Asks are null, so every observable is a constant: a
+        // "still empty" assertion through them cannot fail whether the frames were dropped or not.
+        // The one falsifiable fact about this burst is that it completes without throwing.
+        var book = NewLoadedBook();
+        book.Dispose();
+
+        Exception? thrown = Record.Exception(() =>
+        {
+            book.Clear();
+            book.AddOrUpdateLevel(Delta(isBid: true, price: 101.0, size: 5.0));
+            book.AddOrUpdateLevel(Delta(isBid: false, price: 102.0, size: 5.0));
+            book.DeleteLevel(Delta(isBid: true, price: 101.0, size: 0.0));
+        });
+
+        Assert.True(thrown == null,
+            "A burst of frames landing on a book that a reconnect has just disposed must be dropped "
+            + "silently. It threw: " + Describe(thrown));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // (2) THE RACE — the caller passed the guard BEFORE the dispose landed. The pre-lock
+    //     Volatile.Read(ref _disposed) is check-then-act and cannot see this; only an in-lock null
+    //     re-check of the side list can (the DeleteLevel/CalculateMetrics precedent).
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+
+        Exception? thrown = Record.Exception(() => book.Clear());
+
+        Assert.True(thrown == null,
+            "Clear() (OrderBook.cs:630) read _disposed==false, then the dispose won the race and nulled "
+            + "the side lists under the write lock. Clear() then took the same lock and ran "
+            + "InternalClear() -> _data.Asks.Count() (OrderBook.cs:434) on a null list. The pre-lock flag "
+            + "read cannot close this window; an in-lock null re-check can, as DeleteLevel already does "
+            + "(OrderBook.cs:834-837). It threw: " + Describe(thrown));
+    }
+
+    [Fact]
+    public void AddOrUpdateLevel_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+
+        Exception? thrown = Record.Exception(() =>
+            book.AddOrUpdateLevel(Delta(isBid: true, price: 100.5, size: 2.0)));
+
+        Assert.True(thrown == null,
+            "AddOrUpdateLevel() (OrderBook.cs:656) read _disposed==false, then the dispose won the race. "
+            + "Inside the write lock it dereferenced the nulled side list at _list.Count() "
+            + "(OrderBook.cs:676). This is the frame a Bitfinex/Coinbase socket thread is holding when "
+            + "ClearAsync disposes the book mid-reconnect. It threw: " + Describe(thrown));
+    }
+
+    [Fact]
+    public void AddLevel_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+
+        Exception? thrown = Record.Exception(() => book.AddLevel(
+            IsBid: true,
+            EntryID: string.Empty,
+            Price: 100.5,
+            Size: 2.0,
+            LocalTimeStamp: DateTime.Now,
+            ServerTimeStamp: DateTime.Now));
+
+        Assert.True(thrown == null,
+            "AddLevel() (OrderBook.cs:699) has NO disposed guard at all and takes no lock of its own; it "
+            + "dereferenced the nulled side list at list.Count() (OrderBook.cs:717). CoinbaseL3 "
+            + "(CoinbasePlugin.cs:688, :701, :1021, :1034) and ReplayEngine (ReplayEnginePlugin.cs:1296, "
+            + ":1309) call this entry point directly on books a reconnect can dispose. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void UpdateLevel_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+
+        Exception? thrown = Record.Exception(() => book.UpdateLevel(
+            IsBid: true,
+            EntryID: string.Empty,
+            Price: 100.5,
+            Size: 4.0,
+            LocalTimeStamp: DateTime.Now,
+            ServerTimeStamp: DateTime.Now));
+
+        Assert.True(thrown == null,
+            "UpdateLevel() (OrderBook.cs:776) has NO disposed guard at all and takes no lock of its own; "
+            + "it dereferenced the nulled side list at .Update(..) (OrderBook.cs:786). Reached through "
+            + "OrderBookL3.UpdateLevel (Model_L3/OrderBookL3.cs:73-77) on the L3 book path. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void Reset_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+
+        Exception? thrown = Record.Exception(() => book.Reset());
+
+        Assert.True(thrown == null,
+            "Reset() (OrderBook.cs:649) has NO disposed guard at all: it takes the write lock and runs "
+            + "InternalClear() -> _data.Asks.Count() (OrderBook.cs:434) straight onto the nulled side "
+            + "list. Same shape as the Clear() that was fixed on this branch, same one-line in-lock "
+            + "re-check needed. It threw: " + Describe(thrown));
+    }
+
+    [Fact]
+    public void UpdateSnapshot_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+        BookItem[] asks = { Level(isBid: false, price: 101.5, size: 3.0) };
+        BookItem[] bids = { Level(isBid: true, price: 100.5, size: 2.0) };
+
+        Exception? thrown = Record.Exception(() => book.UpdateSnapshot(asks, bids));
+
+        Assert.True(thrown == null,
+            "UpdateSnapshot() (OrderBook.cs:466) has NO disposed guard at all: it takes the write lock and "
+            + "runs _data.Clear() (OrderBook.cs:471), which iterates the nulled _Asks at "
+            + "OrderBookData.cs:202. This is the entry point a websocket SNAPSHOT frame lands on, and a "
+            + "reconnect re-seeds the book from a snapshot the moment after ClearAsync disposed it. It "
+            + "threw: " + Describe(thrown));
+    }
+
+    [Fact]
+    public void LoadData_WhenTheDisposeLandsAfterTheGuardPassed_IsIgnored_NotAnNre()
+    {
+        var book = DisposedBookWithTheRaceWindowReopened();
+        BookItem[] asks = { Level(isBid: false, price: 101.5, size: 3.0) };
+        BookItem[] bids = { Level(isBid: true, price: 100.5, size: 2.0) };
+
+        bool applied = true;
+        Exception? thrown = Record.Exception(() => applied = book.LoadData(asks, bids));
+
+        Assert.True(thrown == null,
+            "LoadData() (OrderBook.cs:320) has NO disposed guard at all: it takes the write lock and runs "
+            + "_data.Clear() (OrderBook.cs:325), which iterates the nulled _Asks at OrderBookData.cs:202. "
+            + "This is the entry point a REST snapshot lands on during the reconnect that disposed the "
+            + "book. It threw: " + Describe(thrown));
+        // LoadData reports whether it applied the snapshot; a torn-down book applied nothing, and the
+        // one caller that reads the flag (vmOrderBookFlowAnalysis) treats false as "nothing to update".
+        Assert.False(applied, "LoadData() on a torn-down book must report that nothing was applied.");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // (3) THE RACE, DISCRIMINATED — the four tests above cannot tell an IN-LOCK null re-check from a
+    //     PRE-LOCK one, because in them the side lists are already null before the call. These two
+    //     can: the book is fully alive when the mutation starts, so every pre-lock guard (the flag
+    //     read AND any pre-lock null check) passes, and the lists are nulled only while the mutation
+    //     is parked on the write lock. Only a re-check taken INSIDE the lock survives this.
+    //
+    //     Written for the five entry points that actually take the lock: Clear, AddOrUpdateLevel and
+    //     the three added for DEFECT C. AddLevel (OrderBook.cs:699) and UpdateLevel (OrderBook.cs:776)
+    //     take no lock at all, so "in-lock" has no meaning for them until one is added; they are
+    //     covered by the flag-reset tests above.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_WhenTheDisposeLandsWhileItWaitsForTheWriteLock_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+
+        Exception? thrown = MutateWhileTheWriteLockIsHeld(book, b => b.Clear(), teardownLandsWhileParked: true);
+
+        Assert.True(thrown == null,
+            "Clear() (OrderBook.cs:630) was ALIVE and unguardable when it started: _disposed was false "
+            + "and both side lists were populated, so every pre-lock check passes. The teardown then ran "
+            + "to completion while Clear() was parked on the write lock, exactly as OrderBookData.Dispose "
+            + "does (OrderBookData.cs:255-262). Clear() acquired the lock and dereferenced the nulled list "
+            + "at InternalClear() -> _data.Asks.Count() (OrderBook.cs:434). Only a null re-check taken "
+            + "INSIDE the write lock closes this; a stronger read of _disposed cannot. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void AddOrUpdateLevel_WhenTheDisposeLandsWhileItWaitsForTheWriteLock_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+
+        Exception? thrown = MutateWhileTheWriteLockIsHeld(
+            book,
+            b => b.AddOrUpdateLevel(Delta(isBid: true, price: 100.5, size: 2.0)),
+            teardownLandsWhileParked: true);
+
+        Assert.True(thrown == null,
+            "AddOrUpdateLevel() (OrderBook.cs:656) was ALIVE and unguardable when it started, so every "
+            + "pre-lock check passes. The teardown completed while it was parked on the write lock; it "
+            + "then acquired the lock and dereferenced the nulled side list at _list.Count() "
+            + "(OrderBook.cs:676). Only a null re-check taken INSIDE the write lock closes this. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void Reset_WhenTheDisposeLandsWhileItWaitsForTheWriteLock_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+
+        Exception? thrown = MutateWhileTheWriteLockIsHeld(book, b => b.Reset(), teardownLandsWhileParked: true);
+
+        Assert.True(thrown == null,
+            "Reset() (OrderBook.cs:649) was ALIVE and unguardable when it started, so every pre-lock check "
+            + "passes. The teardown completed while it was parked on the write lock; it then acquired the "
+            + "lock and dereferenced the nulled list at InternalClear() -> _data.Asks.Count() "
+            + "(OrderBook.cs:434). Only a null re-check taken INSIDE the write lock closes this. It threw: "
+            + Describe(thrown));
+    }
+
+    [Fact]
+    public void UpdateSnapshot_WhenTheDisposeLandsWhileItWaitsForTheWriteLock_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+        BookItem[] asks = { Level(isBid: false, price: 101.5, size: 3.0) };
+        BookItem[] bids = { Level(isBid: true, price: 100.5, size: 2.0) };
+
+        Exception? thrown = MutateWhileTheWriteLockIsHeld(
+            book,
+            b => b.UpdateSnapshot(asks, bids),
+            teardownLandsWhileParked: true);
+
+        Assert.True(thrown == null,
+            "UpdateSnapshot() (OrderBook.cs:466) was ALIVE and unguardable when it started, so every "
+            + "pre-lock check passes. The teardown completed while it was parked on the write lock; it "
+            + "then acquired the lock and ran _data.Clear() (OrderBook.cs:471) over the nulled _Asks "
+            + "(OrderBookData.cs:202). Only a null re-check taken INSIDE the write lock closes this. It "
+            + "threw: " + Describe(thrown));
+    }
+
+    [Fact]
+    public void LoadData_WhenTheDisposeLandsWhileItWaitsForTheWriteLock_IsIgnored_NotAnNre()
+    {
+        var book = NewLoadedBook();
+        BookItem[] asks = { Level(isBid: false, price: 101.5, size: 3.0) };
+        BookItem[] bids = { Level(isBid: true, price: 100.5, size: 2.0) };
+
+        Exception? thrown = MutateWhileTheWriteLockIsHeld(
+            book,
+            b => b.LoadData(asks, bids),
+            teardownLandsWhileParked: true);
+
+        Assert.True(thrown == null,
+            "LoadData() (OrderBook.cs:320) was ALIVE and unguardable when it started, so every pre-lock "
+            + "check passes. The teardown completed while it was parked on the write lock; it then "
+            + "acquired the lock and ran _data.Clear() (OrderBook.cs:325) over the nulled _Asks "
+            + "(OrderBookData.cs:202). Only a null re-check taken INSIDE the write lock closes this. It "
+            + "threw: " + Describe(thrown));
+    }
+
+    [Fact]
+    public void TheParkedOnTheLockHarness_WithNoTeardown_LetsTheMutationThroughUnharmed()
+    {
+        // Positive control for the two tests above: same choreography — mutation started on its own
+        // thread, parked on the write lock, lock handed over — but WITHOUT the teardown. If this were
+        // to fail (or if it passed while the mutation never actually ran), the NREs above would be an
+        // artefact of the harness rather than of the dispose landing inside the lock.
+        using var book = NewLoadedBook();
+
+        Exception? thrown = MutateWhileTheWriteLockIsHeld(book, b => b.Clear(), teardownLandsWhileParked: false);
+
+        Assert.True(thrown == null,
+            "The harness itself broke Clear() on a book nothing disposed. The two race tests above would "
+            + "then be measuring the harness, not the defect. It threw: " + Describe(thrown));
+        Assert.True(book.GetTOB(true) == null,
+            "Clear() never actually ran: it was handed the write lock but the bid side still has a level. "
+            + "The race tests above would then prove nothing, because the mutation they time never reaches "
+            + "the code under test.");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Guards the guard.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void LiveBook_StillAppliesClearAddAndDelete()
+    {
+        // Guards the guard: making the disposed path a no-op must not turn the LIVE path into one.
+        using var book = new OrderBook(Symbol, PriceDecimalPlaces, MaxDepth);
+
+        book.AddOrUpdateLevel(Delta(isBid: true, price: 100.5, size: 2.0));
+        book.AddOrUpdateLevel(Delta(isBid: false, price: 101.5, size: 3.0));
+
+        BookItem? bestBid = book.GetTOB(true);
+        BookItem? bestAsk = book.GetTOB(false);
+        Assert.True(bestBid != null, "AddOrUpdateLevel did not reach the live book's bid side.");
+        Assert.True(bestAsk != null, "AddOrUpdateLevel did not reach the live book's ask side.");
+        Assert.Equal(100.5, bestBid!.Price!.Value);
+        Assert.Equal(101.5, bestAsk!.Price!.Value);
+
+        book.DeleteLevel(Delta(isBid: false, price: 101.5, size: 0.0));
+        Assert.True(book.GetTOB(false) == null, "DeleteLevel did not remove the level from the live book.");
+
+        book.Clear();
+        Assert.True(book.GetTOB(true) == null, "Clear() did not empty the live book's bid side.");
+
+        var bids = new BookItem[MaxDepth];
+        Assert.Equal(0, book.GetBidsSnapshot(bids));
+    }
+
+    [Fact]
+    public void LiveBook_StillAppliesAddLevelAndUpdateLevel()
+    {
+        // Same guard on the two entry points that get a null re-check for the first time: a fix that
+        // returns unconditionally (or on the wrong condition) would silence the whole L3/replay write
+        // path, which is a far worse defect than the NRE it replaces.
+        using var book = new OrderBook(Symbol, PriceDecimalPlaces, MaxDepth);
+
+        book.AddLevel(
+            IsBid: true,
+            EntryID: string.Empty,
+            Price: 100.5,
+            Size: 2.0,
+            LocalTimeStamp: DateTime.Now,
+            ServerTimeStamp: DateTime.Now);
+
+        BookItem? bestBid = book.GetTOB(true);
+        Assert.True(bestBid != null, "AddLevel did not reach the live book's bid side.");
+        Assert.Equal(100.5, bestBid!.Price!.Value);
+        Assert.Equal(2.0, bestBid.Size!.Value);
+
+        book.UpdateLevel(
+            IsBid: true,
+            EntryID: string.Empty,
+            Price: 100.5,
+            Size: 7.0,
+            LocalTimeStamp: DateTime.Now,
+            ServerTimeStamp: DateTime.Now);
+
+        BookItem? updated = book.GetTOB(true);
+        Assert.True(updated != null, "UpdateLevel removed the level from the live book instead of updating it.");
+        Assert.Equal(7.0, updated!.Size!.Value);
+    }
+
+    [Fact]
+    public void LiveBook_UpdateLevel_OnTheAskSide_TouchesOnlyTheAsk()
+    {
+        // The side selector was hoisted into a local for the null re-check; this pins that the
+        // selector itself still picks the ASK list for IsBid == false (a mutated selector would
+        // route the update to the bid side, or throw on a null IsBid).
+        using var book = NewLoadedBook();
+
+        book.UpdateLevel(
+            IsBid: false,
+            EntryID: string.Empty,
+            Price: 101.5,
+            Size: 9.0,
+            LocalTimeStamp: DateTime.Now,
+            ServerTimeStamp: DateTime.Now);
+
+        BookItem? bestAsk = book.GetTOB(false);
+        BookItem? bestBid = book.GetTOB(true);
+        Assert.True(bestAsk != null, "UpdateLevel on the ask side removed the ask level.");
+        Assert.Equal(9.0, bestAsk!.Size!.Value);
+        Assert.True(bestBid != null, "UpdateLevel on the ask side must leave the bid side alone.");
+        Assert.Equal(2.0, bestBid!.Size!.Value);
+    }
+
+    [Fact]
+    public void LiveBook_StillAppliesReset()
+    {
+        // Guards the guard for DEFECT C: a null re-check that returns on the wrong condition would turn
+        // the recycle path into a silent no-op, leaving stale levels in a book about to be reused.
+        using var book = NewLoadedBook();
+
+        book.Reset();
+
+        Assert.True(book.GetTOB(true) == null, "Reset() did not empty the live book's bid side.");
+        Assert.True(book.GetTOB(false) == null, "Reset() did not empty the live book's ask side.");
+    }
+
+    [Fact]
+    public void LiveBook_StillAppliesUpdateSnapshot()
+    {
+        // Guards the guard for DEFECT C: this is the websocket snapshot path, so a fix that returns
+        // early on a live book would silently stop every reconnect from re-seeding its book.
+        using var book = new OrderBook(Symbol, PriceDecimalPlaces, MaxDepth);
+        BookItem[] asks = { Level(isBid: false, price: 101.5, size: 3.0) };
+        BookItem[] bids = { Level(isBid: true, price: 100.5, size: 2.0) };
+
+        book.UpdateSnapshot(asks, bids);
+
+        BookItem? bestBid = book.GetTOB(true);
+        BookItem? bestAsk = book.GetTOB(false);
+        Assert.True(bestBid != null, "UpdateSnapshot did not reach the live book's bid side.");
+        Assert.True(bestAsk != null, "UpdateSnapshot did not reach the live book's ask side.");
+        Assert.Equal(100.5, bestBid!.Price!.Value);
+        Assert.Equal(2.0, bestBid.Size!.Value);
+        Assert.Equal(101.5, bestAsk!.Price!.Value);
+        Assert.Equal(3.0, bestAsk.Size!.Value);
+    }
+
+    [Fact]
+    public void LiveBook_StillAppliesLoadData()
+    {
+        // Guards the guard for DEFECT C: this is the REST snapshot path. Its return value is part of the
+        // contract, so a fix that bails must not report success on a book it did not load.
+        using var book = new OrderBook(Symbol, PriceDecimalPlaces, MaxDepth);
+        BookItem[] asks = { Level(isBid: false, price: 101.5, size: 3.0) };
+        BookItem[] bids = { Level(isBid: true, price: 100.5, size: 2.0) };
+
+        bool loaded = book.LoadData(asks, bids);
+
+        Assert.True(loaded, "LoadData reported failure on a live book.");
+        BookItem? bestBid = book.GetTOB(true);
+        BookItem? bestAsk = book.GetTOB(false);
+        Assert.True(bestBid != null, "LoadData did not reach the live book's bid side.");
+        Assert.True(bestAsk != null, "LoadData did not reach the live book's ask side.");
+        Assert.Equal(100.5, bestBid!.Price!.Value);
+        Assert.Equal(2.0, bestBid.Size!.Value);
+        Assert.Equal(101.5, bestAsk!.Price!.Value);
+        Assert.Equal(3.0, bestAsk.Size!.Value);
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A book in the state a reconnect actually finds it in: seeded with one level per side, so the
+    /// disposal has real content to tear down and the guard is not trivially satisfied by an empty book.
+    /// </summary>
+    private static OrderBook NewLoadedBook()
+    {
+        var book = new OrderBook(Symbol, PriceDecimalPlaces, MaxDepth);
+        book.AddOrUpdateLevel(Delta(isBid: true, price: 100.5, size: 2.0));
+        book.AddOrUpdateLevel(Delta(isBid: false, price: 101.5, size: 3.0));
+        return book;
+    }
+
+    /// <summary>
+    /// Reproduces the check-then-act window deterministically, with no threads and no timing.
+    ///
+    /// A real dispose runs first, so <c>OrderBookData._Bids</c>/<c>_Asks</c> are genuinely null
+    /// (OrderBookData.cs:255-262) — that is the only state that matters to the code under test. The
+    /// private <c>_disposed</c> flag is then put back to <c>false</c>, which is exactly what a thread
+    /// that already evaluated <c>Volatile.Read(ref _disposed)</c> before the dispose landed is holding.
+    /// No amount of flag reading can distinguish the two, which is the point: the fix must be an in-lock
+    /// null re-check of the side list, not a stronger read of the flag.
+    ///
+    /// The book is intentionally NOT disposed again by the test — it already was.
+    /// </summary>
+    private static OrderBook DisposedBookWithTheRaceWindowReopened()
+    {
+        var book = NewLoadedBook();
+        book.Dispose();
+
+        FieldInfo? disposedFlag = typeof(OrderBook).GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(disposedFlag != null,
+            "OrderBook no longer has a private bool field named '_disposed' (it was at OrderBook.cs:12). "
+            + "This harness simulates the race by resetting that flag; rename it and this test measures nothing.");
+        Assert.Equal(typeof(bool), disposedFlag!.FieldType);
+        Assert.True((bool)disposedFlag.GetValue(book)!,
+            "Dispose() did not set _disposed, so the harness never reached the state it is meant to reopen.");
+
+        disposedFlag.SetValue(book, false);
+        return book;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="mutate"/> against a LIVE book while a simulated dispose owns the write lock,
+    /// and releases the lock only after the side lists are gone. Deterministic — there is no sleep and
+    /// no timing assumption: the test thread waits on <c>ReaderWriterLockSlim.WaitingWriteCount</c>, which
+    /// is a fact about the lock, not a guess about the scheduler.
+    ///
+    /// Sequence:
+    ///   1. test thread takes the book's write lock (the same <c>ReaderWriterLockSlim</c>
+    ///      <c>OrderBookData.Dispose</c> takes, OrderBookData.cs:255);
+    ///   2. the mutation starts on its own thread with the book fully alive — <c>_disposed</c> false,
+    ///      both side lists populated — so it passes every pre-lock guard and parks on the lock;
+    ///   3. once it is provably parked, the test thread nulls <c>_Bids</c>/<c>_Asks</c>, which is what
+    ///      the real teardown does under this lock (OrderBookData.cs:258-259);
+    ///   4. the lock is released and the mutation resumes on the far side of its own guard.
+    ///
+    /// Returns whatever the mutation threw, or null. A dedicated thread (not the pool) keeps this
+    /// independent of thread-pool pressure from parallel test collections. With
+    /// <paramref name="teardownLandsWhileParked"/> false, step 3 is skipped — that is the positive
+    /// control which shows the choreography alone harms nothing.
+    /// </summary>
+    private static Exception? MutateWhileTheWriteLockIsHeld(
+        OrderBook book,
+        Action<OrderBook> mutate,
+        bool teardownLandsWhileParked)
+    {
+        OrderBookData data = ReadBookData(book);
+        var bookLock = data.Lock as ReaderWriterLockSlim;
+        Assert.True(bookLock != null,
+            "OrderBookData.Lock no longer exposes the ReaderWriterLockSlim (it did at OrderBookData.cs:30). "
+            + "This harness needs it to prove the mutation is parked on the write lock.");
+
+        Exception? captured = null;
+        var mutator = new Thread(() =>
+        {
+            try
+            {
+                mutate(book);
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "orderbook-mutation-under-dispose"
+        };
+
+        bool mutationStarted = false;
+        bool joined = false;
+
+        bookLock!.EnterWriteLock();
+        try
+        {
+            mutator.Start();
+            mutationStarted = true;
+
+            var waited = Stopwatch.StartNew();
+            while (bookLock.WaitingWriteCount == 0 && mutator.IsAlive && waited.Elapsed < ParkTimeout)
+            {
+                Thread.Yield();
+            }
+
+            Assert.True(bookLock.WaitingWriteCount > 0,
+                $"The mutation never asked for the write lock within {ParkTimeout.TotalSeconds:0} s "
+                + $"(thread alive: {mutator.IsAlive}). It returned before reaching the lock, so this test "
+                + "measured nothing: the point is to prove the guard is taken INSIDE the lock, which "
+                + "requires the mutation to get that far.");
+
+            if (teardownLandsWhileParked)
+            {
+                NullTheSideLists(data);
+            }
+        }
+        finally
+        {
+            // The park assertion above throws BEFORE the join below on a failure. Joining here as well
+            // means a failed assertion cannot leave a live thread mutating this book — and the
+            // process-wide BookItemPool it borrows from — while the next test runs. Release the lock
+            // first, in its own try, or the join would wait on a thread this one is blocking.
+            try
+            {
+                bookLock.ExitWriteLock();
+            }
+            finally
+            {
+                if (mutationStarted)
+                {
+                    joined = mutator.Join(JoinTimeout);
+                }
+            }
+        }
+
+        Assert.True(joined,
+            $"The mutation did not finish within {JoinTimeout.TotalSeconds:0} s of the write lock being "
+            + "released. Either the guard deadlocked on the same lock it is holding, or the lock was "
+            + "never handed over.");
+
+        return captured;
+    }
+
+    /// <summary>The book's <see cref="OrderBookData"/>, whose lock and side lists this harness drives.</summary>
+    private static OrderBookData ReadBookData(OrderBook book)
+    {
+        FieldInfo? dataField = typeof(OrderBook).GetField("_data", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(dataField != null,
+            "OrderBook no longer has a field named '_data' (it was at OrderBook.cs:15).");
+        var data = dataField!.GetValue(book) as OrderBookData;
+        Assert.True(data != null, "OrderBook._data was null; the book was never constructed properly.");
+        return data!;
+    }
+
+    /// <summary>
+    /// The only part of <c>OrderBookData.Dispose</c> the code under test can observe: the side lists go
+    /// away (OrderBookData.cs:258-259). Called with the write lock already held, as the real teardown
+    /// does — so this is the production teardown's effect, not a shortcut around it.
+    /// </summary>
+    private static void NullTheSideLists(OrderBookData data)
+    {
+        foreach (string name in new[] { "_Bids", "_Asks" })
+        {
+            FieldInfo? field = typeof(OrderBookData).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.True(field != null,
+                $"OrderBookData no longer has a private field named '{name}' (they were at "
+                + "OrderBookData.cs:57-58). This harness nulls them to reproduce what Dispose does.");
+            field!.SetValue(data, null);
+        }
+    }
+
+    /// <summary>
+    /// The snapshot shape: one book level, as <c>LoadData</c> and <c>UpdateSnapshot</c> receive it from a
+    /// REST or websocket snapshot. Not pooled — both entry points copy into their own pooled item.
+    /// </summary>
+    private static BookItem Level(bool isBid, double price, double size)
+    {
+        return new BookItem
+        {
+            IsBid = isBid,
+            EntryID = string.Empty,
+            Price = price,
+            Size = size,
+            Symbol = Symbol,
+            PriceDecimalPlaces = PriceDecimalPlaces,
+            LocalTimeStamp = DateTime.Now,
+            ServerTimeStamp = DateTime.Now
+        };
+    }
+
+    /// <summary>The delta shape the connectors' queue consumers hand to the book, one per venue frame.</summary>
+    private static DeltaBookItem Delta(bool isBid, double price, double size)
+    {
+        return new DeltaBookItem
+        {
+            IsBid = isBid,
+            EntryID = string.Empty,
+            Price = price,
+            Size = size,
+            Symbol = Symbol,
+            LocalTimeStamp = DateTime.Now,
+            ServerTimeStamp = DateTime.Now
+        };
+    }
+
+    private static string Describe(Exception? ex)
+    {
+        if (ex == null)
+            return "(no exception)";
+        return $"{ex.GetType().FullName}: {ex.Message}{ThrowSite(ex)}";
+    }
+
+    /// <summary>
+    /// The frame the exception actually came from. A test that names a specific dereference is worth
+    /// nothing if it only proves that SOMETHING threw, so every failure message here carries the throw
+    /// site: if it is not the line the message names, the test is measuring the wrong thing.
+    /// </summary>
+    private static string ThrowSite(Exception ex)
+    {
+        string? trace = ex.StackTrace;
+        if (string.IsNullOrEmpty(trace))
+            return string.Empty;
+
+        string[] frames = trace.Split('\n');
+        string? inOrderBook = frames.FirstOrDefault(f => f.Contains("VisualHFT.Model.OrderBook", StringComparison.Ordinal));
+        return "\n  thrown at: " + (inOrderBook ?? frames[0]).Trim();
+    }
+}

--- a/tests/Unit/VisualHFT.Commons.Tests/VisualHFT.Commons.Tests.csproj
+++ b/tests/Unit/VisualHFT.Commons.Tests/VisualHFT.Commons.Tests.csproj
@@ -21,6 +21,17 @@
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
+  <!--
+    Serialises the assembly and its test collections, matching the connector test projects. Required
+    here, not cosmetic: OrderBookDisposedGuardTests parks a thread on OrderBookData's
+    ReaderWriterLockSlim and spins on WaitingWriteCount, and every test in this project borrows from
+    the process-wide static BookItemPool that HelperCustomQueueTests also touches. Run in parallel,
+    both facts become order-dependent.
+  -->
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\VisualHFT.Commons\VisualHFT.Commons.csproj" />
   </ItemGroup>

--- a/tests/Unit/VisualHFT.Commons.Tests/xunit.runner.json
+++ b/tests/Unit/VisualHFT.Commons.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## What

- **Reconnection engine** (`BasePluginDataRetriever.HandleConnectionLost`): after the retried `StartAsync` the loop decides from the status the connector left behind (STARTED = success; LOADED = declined, left alone; STOPPED_FAILED = give up, forced or not; STARTING = failed attempt, retried up to the cap; STOPPED/STOPPING = stopped on purpose, exit without retry), announces the matching provider status on every exit, no longer invokes the registered internal-start action itself (every connector's `StartAsync` awaits the same internal start), and delays through `ReconnectBackoffDelayAsync`.
- **Coinbase**: a level-2 delta whose buffer is gone is dropped instead of escalated; a failed REST snapshot fails the start; the trades consumer tolerates an absent book.
- **Coinbase, Bitfinex, Kraken**: clients held by the library interfaces and created through factory seams; the previous pair is torn down on the live outgoing client, then disposed and replaced, inside `InternalStartAsync` under the start/stop lock; the socket teardown (including stored subscriptions) tolerates a dead socket in `ClearAsync` and in `Dispose`; failures log at Error.
- **Bitfinex**: a websocket snapshot arriving while the book map still holds the null placeholder seeded before the REST snapshot is dropped silently.
- **OrderBook**: `Clear`, `AddOrUpdateLevel`, `Reset`, `UpdateSnapshot`, `LoadData` re-check the side lists inside the write lock; `AddLevel`/`UpdateLevel` at the dereference site; a disposed book is a no-op instead of a `NullReferenceException`.
- **SDK template**: comment updated to the reconnection contract.

## Tests

`ReconnectionEngineTests` (12) and `OrderBookDisposedGuardTests` (23) added to the existing test projects; both green.
